### PR TITLE
x313 Initialize Secondary Timers menu

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -4,6 +4,7 @@ menu.chip=Chip
 menu.clock=Clock
 menu.bod=B.O.D.
 menu.pinmapping=Pin Mapping
+menu.INITIALIZE_SECONDARY_TIMERS=Initialize Secondary Timers
 
 attinyx5.name=ATtiny x5 series
 attinyx5.upload.maximum_size=8192
@@ -371,6 +372,9 @@ attinyx313.menu.bod.2v7=B.O.D. Enabled (2.7v)
 attinyx313.menu.bod.2v7.bootloader.high_fuses=0x9B
 attinyx313.menu.bod.4v3=B.O.D. Enabled (4.3v)
 attinyx313.menu.bod.4v3.bootloader.high_fuses=0x99
+attinyx313.menu.INITIALIZE_SECONDARY_TIMERS.0=no
+attinyx313.menu.INITIALIZE_SECONDARY_TIMERS.1=yes
+attinyx313.menu.INITIALIZE_SECONDARY_TIMERS.1.build.extra_flags=-DINITIALIZE_SECONDARY_TIMERS=1
 attinyx313.build.variant=tinyX313
 
 

--- a/avr/variants/tinyX313/pins_arduino.h
+++ b/avr/variants/tinyX313/pins_arduino.h
@@ -34,7 +34,9 @@ static const uint8_t SCL = 16;
 
 
 //Choosing not to initialise saves power and flash. 1 = initialise.
+#ifndef INITIALIZE_SECONDARY_TIMERS
 #define INITIALIZE_SECONDARY_TIMERS              0
+#endif
 /*
   The old standby ... millis on Timer 0.
 */


### PR DESCRIPTION
As proposed in https://github.com/SpenceKonde/ATTinyCore/issues/37#issuecomment-196498423.

Adds Tools > Initialize Secondary Timers  menu. Setting INITIALIZE_SECONDARY_TIMERS to 1 allows PWM on pins 12 and 13 at the expense of power and flash.

This should probably be considered a rough draft of the PR or a proof of concept. I don't know the best wording for the menu item and options and there should be documentation added to explain the purpose of this menu. I haven't tested this(other than verifying that it does cause the correct macro definitions in all IDE versions back to 1.6.2 which is the oldest version that ATTinyCore is compatible with) because I don't have one of these AVRs. I'm happy to make any changes requested and squash to a single commit.
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/13761089/d36484f6-e9f3-11e5-8d19-9b70b40d22ba.gif)