### PR TITLE
Fix deprecated recipe warnings

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -89,7 +89,8 @@ preproc.includes.flags=-w -x c++ -M -MG -MP
 recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+preprocessed_file_path={build.path}/nul
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------

--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -62,7 +62,8 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
-recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
+archive_file_path={build.path}/{archive_file}
+recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm


### PR DESCRIPTION
Fix deprecated recipe warnings without breaking backwards compatibility. Tested back to Arduino IDE 1.6.2, the oldest version that this platform.txt was previously compatible with.

#### recipe.ar.pattern
The previous recipe causes:
```
Warning: platform.txt from core 'ATtiny Universal' contains deprecated recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}", automatically converted to recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}". Consider upgrading this core.
```
when compiling with Arduino IDE 1.6.6+.
The new recipe added in Arduino AVR Boards 1.6.9 causes an error when compiling with Arduino IDE 1.6.5-r5 and previous:
```
avr-gcc: error: C:\Users\per\AppData\Local\Temp\build9139152539266472339.tmp/core.a: No such file or directory
```
To allow backwards compatibility of the new recipe I added the line:
```
archive_file_path={build.path}/{archive_file}
```
This change results in avr-ar commands identical to the previous recipe. The value of `archive_file_path` set in platform.txt is overridden by the value set by the IDE in IDE 1.6.6+.

#### recipe.preproc.macros
The previous recipe causes:
```
Warning: platform.txt from core 'ATtiny Universal' contains deprecated recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}", automatically converted to recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}". Consider upgrading this core.
```
with Arduino IDE 1.6.7+.
The new recipe added in the Arduino IDE 1.6.7 version of Arduino AVR Boards 1.6.9(there are two different versions of Arduino AVR Boards 1.6.9) causes the error when compiling with Arduino IDE 1.6.6:
```
avr-g++: error: missing filename after '-o'
```
To allow backwards compatibility of the new recipe with Arduino IDE 1.6.6 I added the line:
```
preprocessed_file_path={build.path}/nul
```
which causes the following behavior:
- **IDE 1.6.5-r5 and previous**: `recipe.preproc.macros` is not used at all.
- **IDE 1.6.6**: The default value of `preprocessed_file_path` set in platform.txt is used in the recipe.preproc.macros avr-g++ command.
  - **Windows**: The output is written to the null device so no file is created which is the same result as produced by the Arduino AVR Boards 1.6.9 version included with Arduino IDE 1.6.6.
  - **Linux or Mac OS X**(untested): The output is written to a file named nul in the temporary build folder.
- **IDE 1.6.7+**: The default value of `preprocessed_file_path` set in platform.txt is overridden by the value set by the IDE so the generated `recipe.preproc.macros` avr-g++ command is identical to the one if no default value was specified.

So the `recipe.preproc.macros` fix is a bit more of a hack but shouldn't cause any problems.

I'm happy to make any changes to this PR, just let me know. Per