### PR TITLE
Get rid of compiler warnings 

### DIFF
--- a/avr/cores/tiny/WInterrupts.c
+++ b/avr/cores/tiny/WInterrupts.c
@@ -35,7 +35,7 @@
 
 #include "wiring_private.h"
 
-volatile static voidFuncPtr intFunc[NUMBER_EXTERNAL_INTERRUPTS];
+static volatile voidFuncPtr intFunc[NUMBER_EXTERNAL_INTERRUPTS];
 
 #if defined( MCUCR ) && ! defined( EICRA )
   #define EICRA MCUCR

--- a/avr/cores/tiny/WString.cpp
+++ b/avr/cores/tiny/WString.cpp
@@ -548,7 +548,7 @@ int String::lastIndexOf( char theChar ) const
 
 int String::lastIndexOf(char ch, unsigned int fromIndex) const
 {
-	if (fromIndex >= len || fromIndex < 0) return -1;
+	if (fromIndex >= len) return -1;
 	char tempchar = buffer[fromIndex + 1];
 	buffer[fromIndex + 1] = '\0';
 	char* temp = strrchr( buffer, ch );
@@ -564,7 +564,7 @@ int String::lastIndexOf(const String &s2) const
 
 int String::lastIndexOf(const String &s2, unsigned int fromIndex) const
 {
-  	if (s2.len == 0 || len == 0 || s2.len > len || fromIndex < 0) return -1;
+  	if (s2.len == 0 || len == 0 || s2.len > len) return -1;
 	if (fromIndex >= len) fromIndex = len - 1;
 	int found = -1;
 	for (char *p = buffer; p <= buffer + fromIndex; p++) {

--- a/avr/cores/tinymodern/WInterrupts.c
+++ b/avr/cores/tinymodern/WInterrupts.c
@@ -37,7 +37,7 @@
 #include "wiring_private.h"
 #include "core_atomic.h"
 
-volatile static voidFuncPtr intFunc[NUMBER_EXTERNAL_INTERRUPTS];
+static volatile voidFuncPtr intFunc[NUMBER_EXTERNAL_INTERRUPTS];
 
 #if defined( MCUCR ) && ! defined( EICRA )
   #define EICRA MCUCR

--- a/avr/cores/tinymodern/wiring.h
+++ b/avr/cores/tinymodern/wiring.h
@@ -182,7 +182,7 @@ void init(void);
 void pinMode(uint8_t, uint8_t);
 void digitalWrite(uint8_t, uint8_t);
 int digitalRead(uint8_t);
-int analogRead(uint8_t);
+int analogRead(int8_t);
 void analogReference(uint8_t mode);
 void analogWrite(uint8_t, int);
 

--- a/avr/cores/tinymodern/wiring_analog.c
+++ b/avr/cores/tinymodern/wiring_analog.c
@@ -44,7 +44,7 @@ void analogReference(uint8_t mode)
   analog_reference = mode;
 }
 
-int analogRead(uint8_t pin)
+int analogRead(int8_t pin)
 {
   #if defined( CORE_ANALOG_FIRST )
     if ( pin >= CORE_ANALOG_FIRST ) pin -= CORE_ANALOG_FIRST; // allow for channel or pin numbers


### PR DESCRIPTION
Even though the big "issues" where solved earlier, there's still some compiler warning left. As a guy who always enables compiler warnings I find this rather annoying, especially when the fix is as easy as this! 😉 What do you think?