### PR TITLE
Fix embedded image markup for x4 pinout

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Pin Mapping
 ![x5 pin mapping](http://drazzy.com/e/img/PinoutT85a.jpg "Arduino Pin Mapping for ATtiny 85/45/25")
 
 ### ATtiny 24/44/84
-![x4 Pin Mapping](http://drazzy.com/e/img/PinoutT84a.jpg"Arduino Pin Mapping for ATtiny 84/44/24")
+![x4 Pin Mapping](http://drazzy.com/e/img/PinoutT84a.jpg "Arduino Pin Mapping for ATtiny 84/44/24")
 
 ### ATtiny 261/461/861
 ![x61 Pin Mapping](http://drazzy.com/e/img/PinoutT861.jpg "Arduino Pin Mapping for ATtiny 861/461/261")


### PR DESCRIPTION
The previous code was causing the image to not embed. This may have
previously worked and then broken recently when GitHub made the GFM
interpreter strictly follow their [spec](https://github.github.com/gfm/).  I have seen this happen with other Markdown that used to work before that change.

The current README.md looks like this:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/24823068/6afd9742-1baf-11e7-831e-40eb9f1a5ffd.png)
