### PR TITLE
Added support for AVR Dragon, tested in 1.6.7

### DIFF
--- a/avr/externalprogrammers.txt
+++ b/avr/externalprogrammers.txt
@@ -44,3 +44,8 @@ usbtinyisp2.protocol=usbtiny
 usbtinyisp2.program.tool=avrdude
 usbtinyisp2.program.speed=8
 usbtinyisp2.program.extra_params=-B{program.speed}
+
+dragon.name=AVR Dragon ISP mode
+dragon.communication=usb
+dragon.protocol=dragon_isp
+dragon.program.tool=avrdude

--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -45,3 +45,10 @@ usbtinyisp2.protocol=usbtiny
 usbtinyisp2.program.tool=avrdude
 usbtinyisp2.program.speed=8
 usbtinyisp2.program.extra_params=-B{program.speed}
+
+dragon.name=AVR Dragon ISP mode (ATtiny)
+dragon.communication=usb
+dragon.protocol=dragon_isp
+dragon.program.tool=avrdude
+usbtinyisp2.program.extra_params=-Pusb
+


### PR DESCRIPTION
Added Atmel AVR Dragon support to programmers.txt / externalprogrammers.txt. Tested that AVR Dragon option appears when ATTiny841 (no optiboot) selected, and verified that programming works, in Arduino 1.6.7. Thanks! --Michael