### PR TITLE
Support FlashStringHelper in print and println

### DIFF
--- a/avr/cores/tiny/Print.cpp
+++ b/avr/cores/tiny/Print.cpp
@@ -200,6 +200,30 @@ size_t Print::println( fstr_t* s )
   return( n );
 }
 
+#ifdef FLASHSTRING_SUPPORT
+
+size_t Print::print(const __FlashStringHelper *ifsh)
+{
+  PGM_P p = reinterpret_cast<PGM_P>(ifsh);
+  size_t n = 0;
+  while (1) {
+    unsigned char c = pgm_read_byte(p++);
+    if (c == 0) break;
+    if (write(c)) n++;
+    else break;
+  }
+  return n;
+}
+
+size_t Print::println(const __FlashStringHelper *ifsh)
+{
+  size_t n = print(ifsh);
+  n += println();
+  return n;
+}
+
+#endif
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base) {

--- a/avr/cores/tiny/Print.h
+++ b/avr/cores/tiny/Print.h
@@ -42,6 +42,8 @@
 
 #define ARDUINO_CORE_PRINTABLE_SUPPORT
 
+#define FLASHSTRING_SUPPORT
+
 class Print;
 
 /* Printable...*/
@@ -103,6 +105,11 @@ class Print
     size_t println(unsigned long, int = DEC);
     size_t println(double, int = 2);
     size_t println(void);
+
+    #ifdef FLASHSTRING_SUPPORT
+    size_t print(const __FlashStringHelper *ifsh);
+    size_t println(const __FlashStringHelper *ifsh);
+    #endif
 };
 
 #endif


### PR DESCRIPTION
First of all, thanks for all your work on the core!

This PR adds support for [PROGMEM strings](https://www.arduino.cc/en/Reference/PROGMEM) (e.g. F("Hello")) in the Print class. This removes the dependency on some dynamic functions to handle PROGMEM strings. I did some analysis and it seems at least these functions are not included in the ELF file afterwards:

| Function                           | Size       |
| -----------------------------------|------------|
| String(__FlashStringHelper*)       |  18 bytes  |
| String::copy(__FlashStringHelper*) |  86 bytes  |
| String::changeBuffer               |  50 bytes  |
| String::reserve                    |  46 bytes  |
| __strlen_P                         |  18 bytes  |
| strcpy_P                           |  14 bytes  |
| memcpy                             |  18 bytes  |
| malloc                             | 298 bytes  |
| realloc                            | 390 bytes  |
| free                               | 304 bytes  |
| **Total**                          | **1242 bytes** |

There are probably some others too.

I also did some tests using core v1.1.2 and v1.1.3, with this sketch:
```Arduino
#if 1 // 1 -> Use TinyDebugSerial, 0 -> Use core Serial (+304 bytes)
  #include <TinyDebugSerial.h>
  TinyDebugSerial TDSerial;
  #define MySerial TDSerial
#else
  #define MySerial Serial
#endif

void setup() {
  MySerial.begin(9600);
  MySerial.println(F("Hello World"));
}

void loop() {
}
```

The total program storage space for each:
```
v1.1.2 using TinyDebugSerial
2212 bytes
 724 bytes

v1.1.3 using TinyDebugSerial
2228 bytes
 740 bytes

v1.1.3 using core's Serial
2532 bytes
1044 bytes
```

There is a consistent reduction of 1488 bytes. That's more than a third of ATTiny45's 4k memory.