### PR TITLE
 New features in tinySPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,19 @@ On the following chips, full master/slave I2C functionality is provided in hardw
 SPI support:
 ------------
 
-On the following chips, SPI functionality can be achieved with the hardware USI - as of version 1.1.3 of this core, this should be handled transparently via the SPI library. Take care to note that the **USI does not have MISO/MOSI, it has DI/DO**; when operating in master mode, DI is MISO, and DO is MOSI. When operating in slave mode, DI is MOSI and DO is MISO. The #defines for MISO and MOSI assume master mode (as this is much more common).  
+On the following chips, full SPI functionality is provided in hardware, and works identically to SPI on Atmega chips:
+* ATtiny 828
+* ATtiny x7 (87/167) (it has both a USI and full SPI, but the SPI library will use the SPI hardware)
+* ATtiny x41 (441/841)
+* ATtiny x8 (48, 88)
+
+On the following chips, SPI functionality can be achieved with the hardware USI - as of version 1.1.3 of this core, this should be handled transparently via the SPI library. Take care to note that the **USI does not have MISO/MOSI, it has DI/DO**; when operating in master mode, DI is MISO, and DO is MOSI. When operating in slave mode, DI is MOSI and DO is MISO. The #defines for MISO and MOSI assume master mode (as this is much more common). Clock dividers 2, 4, 8 and >=14 are implemented as separate routines; **call `SPISettings` or `setClockDivider` with a constant value to use less program space**, otherwise, all routines will be included along with 32-bit math. Clock dividers larger than 14 are only approximate because the routine is optimized for size, not exactness. Also, interrupts are not disabled during data transfer as SPI clock doesn't need to be precise in most cases. If you use long interrupt routines or require consistent clocking, wrap calls to `transfer` in `ATOMIC_BLOCK`.
 * ATtiny x5 (25/45/85)
 * ATtiny x4 (24/44/84)
 * ATtiny x61 (262/461/861)
 * ATtiny x7 (87/167)
 * ATtiny x313 (2313/4313)
 * ATtiny 1634
-
-On the following chips, full SPI functionality is provided in hardware, and works identically to SPI on Atmega chips:
-* ATtiny 828
-* ATtiny x7 (87/167) (it has both a USI and full SPI, but the SPI library will use the SPI hardware)
-* ATtiny x41 (441/841)
-* ATtiny x8 (48, 88)
 
 Serial Support
 -------

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -269,10 +269,16 @@ void tinySPI::begin(void)
 
 void tinySPI::setDataMode(uint8_t spiDataMode)
 {
-    if (spiDataMode == SPI_MODE1)
+    if (spiDataMode == SPI_MODE1) {
         USICR |= _BV(USICS0);
-    else
+    } else {
         USICR &= ~_BV(USICS0);
+    }
+    if (spiDataMode == SPI_MODE2 || spiDataMode == SPI_MODE3) {
+        digitalWrite(SCK, HIGH);
+    } else {
+        digitalWrite(SCK, LOW);
+    }
 }
 
 USI_impl::ClockOut USI_impl::dispatchClockout_slow(uint8_t div, uint8_t* delay)
@@ -458,6 +464,11 @@ void tinySPI::beginTransaction(SPISettings settings) {
     msb1st = settings.msb1st ;
     delay = settings.delay;
     clockoutfn = settings.clockoutfn;
+    if (settings.cpol) {
+        digitalWrite(SCK, HIGH);
+    } else {
+        digitalWrite(SCK, LOW);
+    }
   }
 
 void tinySPI::endTransaction(void) {

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -250,7 +250,7 @@ tinySPI::tinySPI()
 
 USI_impl::ClockOut tinySPI::clockoutfn = 0;
 uint8_t tinySPI::delay = 0;
-uint8_t tinySPI::msb1st = 0;
+uint8_t tinySPI::msb1st = MSBFIRST;
 uint8_t tinySPI::initialized = 0;
 
 uint8_t tinySPI::interruptMode = 0;

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -307,12 +307,10 @@ __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI2(uint8_t data, uint8_t)
 {
     uint8_t tmp = USICR | _BV(USITC);
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
-        USISR = _BV(USIOIF);  //clear counter and counter overflow interrupt flag
-        USIDR = data;
-        for (byte i = 0; i < 16; ++i) {
-            USICR = tmp; // compiles to out, one cycle
-        }
+    USISR = _BV(USIOIF);  //clear counter and counter overflow interrupt flag
+    USIDR = data;
+    for (byte i = 0; i < 16; ++i) {
+        USICR = tmp; // compiles to out, one cycle
     }
     return USIDR;
 }
@@ -320,12 +318,10 @@ uint8_t USI_impl::clockoutUSI2(uint8_t data, uint8_t)
 __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI4(uint8_t data, uint8_t)
 {
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
-        USISR = _BV(USIOIF);
-        USIDR = data;
-        for (byte i = 0; i < 16; ++i) {
-            USICR |= _BV(USITC); // compiles to sbi, two cycles
-        }
+    USISR = _BV(USIOIF);
+    USIDR = data;
+    for (byte i = 0; i < 16; ++i) {
+        USICR |= _BV(USITC); // compiles to sbi, two cycles
     }
     return USIDR;
 }
@@ -334,13 +330,11 @@ __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI8(uint8_t data, uint8_t)
 {
     uint8_t tmp = USICR | _BV(USITC);
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
-        USISR = _BV(USIOIF);
-        USIDR = data;
-        for (byte i = 0; i < 16; ++i) {
-            USICR = tmp; // compiles to out, one cycle
-            _delay_loop_1(1); // 7 cycles, 1 cycle overhead on first bit
-        }
+    USISR = _BV(USIOIF);
+    USIDR = data;
+    for (byte i = 0; i < 16; ++i) {
+        USICR = tmp; // compiles to out, one cycle
+        _delay_loop_1(1); // 7 cycles, 1 cycle overhead on first bit
     }
     return USIDR;
 }
@@ -349,7 +343,6 @@ __attribute__((optimize ("Os")))
 uint8_t USI_impl::clockoutUSI(uint8_t data, uint8_t delay)
 {
     uint8_t tmp = USICR | _BV(USITC);
-    // Low speed, do not disable interrupts.
     USISR = _BV(USIOIF);
     USIDR = data;
     for (byte i = 0; i < 16; ++i) {

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -308,19 +308,13 @@ uint8_t USI_impl::clockoutUSI2(uint8_t data, uint8_t)
     // Unlike other clockout methods, this one cannot rely on the
     // "external" clock source (USICS1) because it is too slow and
     // glitches. Instead, it uses software strobe explicitly.
-    uint8_t strobe1;
-    uint8_t strobe2;
-    // Use asm to prevent instruction reordering.
-    asm volatile ("ldi %[strobe1], %[value1] \n\t"
-                  "ldi %[strobe2], %[value2] \n\t"
-                  : [strobe1] "=r" (strobe1),
-                    [strobe2] "=r" (strobe2)
-                  : [value1] "M" (_BV(USIWM0) | _BV(USITC)),
-                    [value2] "M" (_BV(USIWM0) | _BV(USITC) | _BV(USICLK)));
+    uint8_t strobe1 = _BV(USIWM0) | _BV(USITC);
+    uint8_t strobe2 = _BV(USIWM0) | _BV(USITC) | _BV(USICLK);
     uint8_t usicr = USICR;
     bool mode1 = usicr & _BV(USICS0);
     USISR = _BV(USIOIF);  //clear counter and counter overflow interrupt flag
     USIDR = data;
+    // Use asm to prevent instruction reordering.
     if (!mode1) {
         asm volatile("out %[usicr], %[strobe1] \n\t"
                      "out %[usicr], %[strobe2] \n\t"

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -372,11 +372,15 @@ void tinySPI::setClockDivider(uint8_t div)
 
 uint8_t tinySPI::transfer(uint8_t spiData)
 {
-    uint8_t retval = clockoutfn((msb1st ? spiData : reverse(spiData)), clockdiv);
-    return msb1st ? retval : reverse(retval);
+    if (msb1st) {
+        return clockoutfn(spiData, clockdiv);
+    } else {
+        return reverse(clockoutfn(reverse(spiData), clockdiv));
+    }
 }
 
-uint16_t tinySPI::transfer16(uint16_t data) {
+uint16_t tinySPI::transfer16(uint16_t data)
+{
     union { uint16_t val; struct { uint8_t lsb; uint8_t msb; }; } tmp;
     tmp.val = data;
     if (msb1st) {

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -348,7 +348,7 @@ void tinySPI::transfer(void *buf, size_t count) {
  *p = USIDR;
 }
 
-static void tinySPI::beginTransaction(SPISettings settings) {
+void tinySPI::beginTransaction(SPISettings settings) {
     if (interruptMode > 0) {
       uint8_t sreg = SREG;
       noInterrupts();
@@ -368,7 +368,7 @@ static void tinySPI::beginTransaction(SPISettings settings) {
     reversebit=settings.reverse;
   }
 
-static void tinySPI::endTransaction(void) {
+void tinySPI::endTransaction(void) {
   if (interruptMode > 0) {
     #ifdef SPI_AVR_EIMSK
     uint8_t sreg = SREG;

--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -306,10 +306,10 @@ static byte reverse (byte x){
 __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI2(uint8_t data, uint8_t)
 {
-    USIDR = data;
-    USISR = _BV(USIOIF);  //clear counter and counter overflow interrupt flag
     uint8_t tmp = USICR | _BV(USITC);
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
+        USISR = _BV(USIOIF);  //clear counter and counter overflow interrupt flag
+        USIDR = data;
         for (byte i = 0; i < 16; ++i) {
             USICR = tmp; // compiles to out, one cycle
         }
@@ -320,9 +320,9 @@ uint8_t USI_impl::clockoutUSI2(uint8_t data, uint8_t)
 __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI4(uint8_t data, uint8_t)
 {
-    USIDR = data;
-    USISR = _BV(USIOIF);
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
+        USISR = _BV(USIOIF);
+        USIDR = data;
         for (byte i = 0; i < 16; ++i) {
             USICR |= _BV(USITC); // compiles to sbi, two cycles
         }
@@ -333,10 +333,10 @@ uint8_t USI_impl::clockoutUSI4(uint8_t data, uint8_t)
 __attribute__((optimize (3, "unroll-all-loops")))
 uint8_t USI_impl::clockoutUSI8(uint8_t data, uint8_t)
 {
-    USIDR = data;
-    USISR = _BV(USIOIF);
     uint8_t tmp = USICR | _BV(USITC);
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { // ensure a consistent clock period
+        USISR = _BV(USIOIF);
+        USIDR = data;
         for (byte i = 0; i < 16; ++i) {
             USICR = tmp; // compiles to out, one cycle
             _delay_loop_1(2); // 7 cycles
@@ -348,10 +348,10 @@ uint8_t USI_impl::clockoutUSI8(uint8_t data, uint8_t)
 __attribute__((optimize ("Os")))
 uint8_t USI_impl::clockoutUSI(uint8_t data, uint8_t div)
 {
-    USIDR = data;
-    USISR = _BV(USIOIF);
     uint8_t tmp = USICR | _BV(USITC);
     // Low speed, do not disable interrupts.
+    USISR = _BV(USIOIF);
+    USIDR = data;
     for (byte i = 0; i < 16; ++i) {
         USICR = tmp; // compiles to out, one cycle
         _delay_loop_1(div); // div calculated by SPISettings.

--- a/avr/libraries/SPI/SPI.h
+++ b/avr/libraries/SPI/SPI.h
@@ -350,7 +350,9 @@ extern SPIClass SPI;
 
 //SPI data modes
 #define SPI_MODE0 0x00
-#define SPI_MODE1 0x04
+#define SPI_MODE1 0x01
+#define SPI_MODE2 0x02
+#define SPI_MODE3 0x03
 
 #define SPI_CLOCK_DIV2       2
 #define SPI_CLOCK_DIV4       4
@@ -408,10 +410,11 @@ private:
   void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
     __attribute__((always_inline)) {
     usicr = _BV(USIWM0) | _BV(USICS1) | _BV(USICLK);
-    if (dataMode == SPI_MODE1) {
+    if (dataMode == SPI_MODE1 || dataMode == SPI_MODE3) {
         usicr |= _BV(USICS0);
     }
     msb1st = bitOrder;
+    cpol = dataMode == SPI_MODE2 || dataMode == SPI_MODE3;
     // Round up.
     uint8_t div = F_CPU / clock + (F_CPU % clock ? 1 : 0);
     if (__builtin_constant_p(clock)) {
@@ -422,6 +425,7 @@ private:
   }
 
   uint8_t msb1st;
+  uint8_t cpol;
   uint8_t usicr;
   uint8_t delay;
   USI_impl::ClockOut clockoutfn;

--- a/avr/libraries/SPI/SPI.h
+++ b/avr/libraries/SPI/SPI.h
@@ -402,7 +402,7 @@ public:
     init_AlwaysInline(clock, bitOrder, dataMode);
   }
   SPISettings() {
-    init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0);
+    init_AlwaysInline(F_CPU / 16, MSBFIRST, SPI_MODE0);
   }
 private:
   void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)

--- a/avr/libraries/SPI/SPI.h
+++ b/avr/libraries/SPI/SPI.h
@@ -405,7 +405,10 @@ public:
 private:
   void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
     __attribute__((always_inline)) {
-    usicr = (dataMode == SPI_MODE1) ? 0x1E : 0x1A;
+    usicr = _BV(USIWM0) | _BV(USICS1) | _BV(USICLK);
+    if (dataMode == SPI_MODE1) {
+        usicr |= _BV(USICS0);
+    }
     msb1st = bitOrder;
     if (__builtin_constant_p(clock)) {
       clockoutfn = USI_impl::dispatchClockout(F_CPU / clock, &clockdiv);

--- a/avr/libraries/SPI/SPI.h
+++ b/avr/libraries/SPI/SPI.h
@@ -412,10 +412,12 @@ private:
         usicr |= _BV(USICS0);
     }
     msb1st = bitOrder;
+    // Round up.
+    uint8_t div = F_CPU / clock + (F_CPU % clock ? 1 : 0);
     if (__builtin_constant_p(clock)) {
-      clockoutfn = USI_impl::dispatchClockout(F_CPU / clock, &delay);
+      clockoutfn = USI_impl::dispatchClockout(div, &delay);
     } else {
-      clockoutfn = USI_impl::dispatchClockout_slow(F_CPU / clock, &delay);
+      clockoutfn = USI_impl::dispatchClockout_slow(div, &delay);
     }
   }
 


### PR DESCRIPTION
This PR fixes #180 and #134, implements
  * USI clocking with dividers 2, 4, 8 and >=14
  * SPI modes 2 and 3

Code size has increased, but mostly on account of fixes because previously, the `transfer` routines did not properly reverse data in the LSBFIRST case. Compiling a simple sketch that uses `SPISettings` and all three `transfer` functions, code size increases by:
  * 302 bytes for fixes, new modes and clock selection support
  * 24 bytes for clock divider >=14
  * 84 bytes for divider 2
  * 38 bytes for divider 4
  * 138 bytes for divider 8
  * 556 bytes when clock speed is not a compile-time constant

Caveat: the only SPI slave I have available uses SPI_MODE0 and MSBFIRST order. I tested the other modes with a logic analyzer and they seem to work, but I would feel better if someone tested them with actual devices.