### PR TITLE
Add missing yield function prototypes

### DIFF
--- a/avr/cores/tiny/Arduino.h
+++ b/avr/cores/tiny/Arduino.h
@@ -17,6 +17,8 @@ extern "C"{
 
 #define ATTINY_CORE 1
 
+void yield(void);
+
 #define HIGH 0x1
 #define LOW  0x0
 

--- a/avr/cores/tinymodern/wiring.h
+++ b/avr/cores/tinymodern/wiring.h
@@ -38,6 +38,8 @@
 extern "C"{
 #endif
 
+void yield(void);
+
 #define HIGH 0x1
 #define LOW  0x0
 


### PR DESCRIPTION
Missing function prototypes for `yield()` in the cores caused compilation to fail for any code that called this function:
```
error: 'yield' was not declared in this scope
```

I placed them above the `HIGH` and `LOW` definitions to match the Arduino AVR Boards core:
https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Arduino.h#L38

Fixes https://github.com/SpenceKonde/ATTinyCore/issues/187