### PR TITLE
tinySPI: apply default settings in begin() for compatibility.

### DIFF
--- a/avr/libraries/SPI/SPI.cpp
+++ b/avr/libraries/SPI/SPI.cpp
@@ -251,7 +251,6 @@ tinySPI::tinySPI()
 USI_impl::ClockOut tinySPI::clockoutfn = 0;
 uint8_t tinySPI::delay = 0;
 uint8_t tinySPI::msb1st = MSBFIRST;
-uint8_t tinySPI::initialized = 0;
 
 uint8_t tinySPI::interruptMode = 0;
 uint8_t tinySPI::interruptMask = 0;
@@ -264,7 +263,7 @@ void tinySPI::begin(void)
     USI_SCK_PORT |= _BV(USCK_DD_PIN);   //set the USCK pin as output
     USI_DDR_PORT |= _BV(DO_DD_PIN);     //set the DO pin as output
     USI_DDR_PORT &= ~_BV(DI_DD_PIN);    //set the DI pin as input
-    initialized++;
+    applySettings(SPISettings());
 }
 
 void tinySPI::setDataMode(uint8_t spiDataMode)
@@ -443,6 +442,18 @@ void tinySPI::transfer(void* _buf, size_t count) {
     }
 }
 
+void tinySPI::applySettings(SPISettings settings) {
+    USICR = settings.usicr;
+    msb1st = settings.msb1st ;
+    delay = settings.delay;
+    clockoutfn = settings.clockoutfn;
+    if (settings.cpol) {
+        digitalWrite(SCK, HIGH);
+    } else {
+        digitalWrite(SCK, LOW);
+    }
+}
+
 void tinySPI::beginTransaction(SPISettings settings) {
     if (interruptMode > 0) {
       uint8_t sreg = SREG;
@@ -459,15 +470,7 @@ void tinySPI::beginTransaction(SPISettings settings) {
         interruptSave = sreg;
       }
     }
-    USICR = settings.usicr;
-    msb1st = settings.msb1st ;
-    delay = settings.delay;
-    clockoutfn = settings.clockoutfn;
-    if (settings.cpol) {
-        digitalWrite(SCK, HIGH);
-    } else {
-        digitalWrite(SCK, LOW);
-    }
+    applySettings(settings);
   }
 
 void tinySPI::endTransaction(void) {

--- a/avr/libraries/SPI/SPI.h
+++ b/avr/libraries/SPI/SPI.h
@@ -464,7 +464,8 @@ class tinySPI
   static void notUsingInterrupt(uint8_t interruptNumber);
 
 private:
-  static uint8_t initialized;
+  static void applySettings(SPISettings settings);
+
   static uint8_t msb1st;
   static uint8_t delay;
   static USI_impl::ClockOut clockoutfn;


### PR DESCRIPTION
Express patch, delivered by exzombie's same-day service :) . Seriously, setting up an UNO as a slave was easier than I expected, so I was able to test all modes besides MODE0 and MSBFIRST. And of course, I need to thank the wife for cutting me some slack ;) . All modes seem to work fine. Using a slave tests input as well, so sure beats a logic analyzer. I'm proud to say that the code works, the worries I expressed in #196 are worries no more.