### PR TITLE
uncomment PWM1B setting to make millis() work on ATtiny85 if TIMER_TO…

### DIFF
--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -743,7 +743,7 @@ void init(void)
   //#if !defined(__AVR_ATtiny85__)
  // sbi(TCCR1, PWM1A); //for the tiny 85, Timer0 is used instead.
   //#endif
-  //sbi(GTCCR, PWM1B);
+  sbi(GTCCR, PWM1B);
   OCR1C = 0xFF; //Use 255 as the top to match with the others as this module doesn't have a 8bit PWM mode.
   #elif (TIMER_TO_USE_FOR_MILLIS == 1) && defined(TCCR1E)
   sbi(TCCR1C, PWM1D);


### PR DESCRIPTION
millis() did not work for me on an ATtiny85 if TIMER_TO_USE_FOR_MILLIS =1.
It looked like the overflow interrupt never fires.
The proposed patch works for me.  I assume, that this was a typo.
Commenting line 742 sbi(TCCR1, CTC1) instead did also work.
I am not sure about the intended behaviour.

By the way: could I just set OCR1C =249 making the interrupt fire exactly every 2ms?
This would save al lot of code dealing with the FRACT_INC stuff.