### PR TITLE
Disable hardware UART with a #define ( #223 )

### DIFF
--- a/Internals.md
+++ b/Internals.md
@@ -19,6 +19,7 @@ These are used to identify features:
 #define USE_SOFTWARE_SERIAL    (0 = hardware serial, 1 = software serial
 #define USE_SOFTWARE_SPI       (not defined if hardware spi present)
 #define HAVE_ADC               (1 = has ADC functions)
+#define DISABLE_UART           (1 = disables HW serial buffers and interrupts)
 
 ```
 

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -30,7 +30,8 @@
 
 // this next line disables the entire HardwareSerial.cpp,
 // this is so I can support Attiny series and any other chip without a uart
-#if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(LINBRRH)) && !USE_SOFTWARE_SERIAL
+// (If DISABLE_UART is set, HW serial is disabled, skipping this file and freeing up memory.)
+#if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(LINBRRH)) && !USE_SOFTWARE_SERIAL && !DISABLE_UART
 
 #include "HardwareSerial.h"
 

--- a/avr/cores/tinymodern/HardwareSerial.cpp
+++ b/avr/cores/tinymodern/HardwareSerial.cpp
@@ -31,7 +31,8 @@
 
 // this next line disables the entire HardwareSerial.cpp,
 // this is so I can support Attiny series and any other chip without a uart
-#if defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H)
+// (If DISABLE_UART is set in core_build_options.h, HW serial is disabled completely.)
+#if defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H) && !DISABLE_UART
 
 #include "HardwareSerial.h"
 

--- a/avr/cores/tinymodern/core_build_options.h
+++ b/avr/cores/tinymodern/core_build_options.h
@@ -56,6 +56,12 @@
 
 #define DEFAULT_TO_TINY_DEBUG_SERIAL              0
 
+/*=============================================================================
+  Disable HW serial support completely, freeing up flash and RAM
+=============================================================================*/
+
+#define DISABLE_UART                              0
+
 
 // missing defines (?)
 #if !defined(PCINT0)


### PR DESCRIPTION
Using pre-existing logic for disabling UART entirely for chips with no serial peripheral, a tinymodern/core_build_options.h #define DISABLE_UART disables hardware UART support by skipping the entire HardwareSerial.cpp file. Also added to tiny/HardwareSerial.cpp and referenced in Internals.md. #define has no effect if software serial is enabled.