### PR TITLE
convert USIWire names to TwoWire

### DIFF
--- a/avr/libraries/Wire/src/USIWire.cpp
+++ b/avr/libraries/Wire/src/USIWire.cpp
@@ -33,20 +33,20 @@ const uint8_t WIRE_BUFFER_LENGTH = TWI_BUFFER_SIZE - 1; //reserve slave addr
 
 // Initialize Class Variables //////////////////////////////////////////////////
 
-uint8_t *USIWire::Buffer = TWI_Buffer;
-uint8_t USIWire::BufferIndex = 0;
-uint8_t USIWire::BufferLength = 0;
+uint8_t *TwoWire::Buffer = TWI_Buffer;
+uint8_t TwoWire::BufferIndex = 0;
+uint8_t TwoWire::BufferLength = 0;
 
-uint8_t USIWire::transmitting = 0;
+uint8_t TwoWire::transmitting = 0;
 
 // Constructors ////////////////////////////////////////////////////////////////
 
-USIWire::USIWire() {
+TwoWire::TwoWire() {
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void USIWire::begin(void) {
+void TwoWire::begin(void) {
   BufferIndex = 0;
   BufferLength = 0;
 
@@ -55,7 +55,7 @@ void USIWire::begin(void) {
   USI_TWI_Master_Initialise();
 }
 
-void USIWire::begin(uint8_t address) {
+void TwoWire::begin(uint8_t address) {
   BufferIndex = 0;
   BufferLength = 0;
 
@@ -63,20 +63,20 @@ void USIWire::begin(uint8_t address) {
   USI_TWI_Slave_Initialise(address);
 }
 
-void USIWire::begin(int address) {
+void TwoWire::begin(int address) {
   begin((uint8_t)address);
 }
 
-void USIWire::end(void) {
+void TwoWire::end(void) {
   USI_TWI_Slave_Disable();
 }
 
-void USIWire::setClock(uint32_t clock) {
+void TwoWire::setClock(uint32_t clock) {
   // XXX: to be implemented.
   (void)clock; //disable warning
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity,
                              uint32_t iaddress, uint8_t isize,
                              uint8_t sendStop) {
   if (isize > 0) {
@@ -122,25 +122,25 @@ uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
   return quantity - 1; // ignore slave address
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity,
                              uint8_t sendStop) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint32_t)0,
                      (uint8_t)0, (uint8_t)sendStop);
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity) {
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
 }
 
-uint8_t USIWire::requestFrom(int address, int quantity) {
+uint8_t TwoWire::requestFrom(int address, int quantity) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
 }
 
-uint8_t USIWire::requestFrom(int address, int quantity, int sendStop) {
+uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
 }
 
-void USIWire::beginTransmission(uint8_t address) {
+void TwoWire::beginTransmission(uint8_t address) {
   // indicate that we are transmitting
   transmitting = 1;
   // set address of targeted slave and write mode
@@ -150,11 +150,11 @@ void USIWire::beginTransmission(uint8_t address) {
   BufferLength = BufferIndex;
 }
 
-void USIWire::beginTransmission(int address) {
+void TwoWire::beginTransmission(int address) {
   beginTransmission((uint8_t)address);
 }
 
-uint8_t USIWire::endTransmission(uint8_t sendStop) {
+uint8_t TwoWire::endTransmission(uint8_t sendStop) {
   // transmit buffer (blocking)
   uint8_t ret = USI_TWI_Start_Transceiver_With_Data_Stop(Buffer,
                                                          BufferLength,
@@ -179,14 +179,14 @@ uint8_t USIWire::endTransmission(uint8_t sendStop) {
   return 0; //success
 }
 
-uint8_t USIWire::endTransmission(void) {
+uint8_t TwoWire::endTransmission(void) {
   return endTransmission(true);
 }
 
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(uint8_t data) {
+size_t TwoWire::write(uint8_t data) {
   if (transmitting) { // in master transmitter mode
     // don't bother if buffer is full
     if (BufferLength >= TWI_BUFFER_SIZE) {
@@ -211,7 +211,7 @@ size_t USIWire::write(uint8_t data) {
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(const uint8_t *data, size_t quantity) {
+size_t TwoWire::write(const uint8_t *data, size_t quantity) {
   size_t numBytes = 0;
   for (size_t i = 0; i < quantity; ++i){
     numBytes += write(data[i]);
@@ -222,7 +222,7 @@ size_t USIWire::write(const uint8_t *data, size_t quantity) {
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(const char *str) {
+size_t TwoWire::write(const char *str) {
   if (str == NULL) return 0;
   return write((const uint8_t *)str, strlen(str));
 }
@@ -230,7 +230,7 @@ size_t USIWire::write(const char *str) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::available(void) {
+int TwoWire::available(void) {
   if (BufferLength) {
     return BufferLength - BufferIndex;
   } else {
@@ -241,7 +241,7 @@ int USIWire::available(void) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::read(void) {
+int TwoWire::read(void) {
   int value = -1;
 
   // get each successive byte on each call
@@ -260,7 +260,7 @@ int USIWire::read(void) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::peek(void) {
+int TwoWire::peek(void) {
   int value = -1;
 
   if (available()) {
@@ -274,26 +274,26 @@ int USIWire::peek(void) {
   return value;
 }
 
-void USIWire::flush(void) {
+void TwoWire::flush(void) {
   // XXX: to be implemented.
 }
 
 // sets function called on slave write
-void USIWire::onReceive( void (*function)(int) ) {
+void TwoWire::onReceive( void (*function)(int) ) {
   USI_TWI_On_Slave_Receive = function;
 }
 
 // sets function called on slave read
-void USIWire::onRequest( void (*function)(void) ) {
+void TwoWire::onRequest( void (*function)(void) ) {
   USI_TWI_On_Slave_Transmit = function;
 }
 
 // return true on I2C/TWI activity
-uint8_t USIWire::isActive(void) {
+uint8_t TwoWire::isActive(void) {
   return USI_TWI_Slave_Is_Active();
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////
 
-USIWire Wire = USIWire();
+TwoWire Wire = TwoWire();
 #endif

--- a/avr/libraries/Wire/src/USIWire.h
+++ b/avr/libraries/Wire/src/USIWire.h
@@ -31,7 +31,7 @@ extern const uint8_t WIRE_BUFFER_LENGTH;
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
-class USIWire {
+class TwoWire {
   private:
     static uint8_t *Buffer;
     static uint8_t BufferIndex;
@@ -39,7 +39,7 @@ class USIWire {
 
     static uint8_t transmitting;
   public:
-    USIWire();
+    TwoWire();
     void begin();
     void begin(uint8_t);
     void begin(int);
@@ -71,7 +71,7 @@ class USIWire {
     inline size_t write(int n) { return write((uint8_t)n); }
 };
 
-extern USIWire Wire;
+extern TwoWire Wire;
 
 #endif
 #endif

--- a/avr/libraries/Wire/src/Wire.cpp
+++ b/avr/libraries/Wire/src/Wire.cpp
@@ -244,7 +244,7 @@ int TwoWire::available(void)
 int TwoWire::read(void)
 {
   int value = -1;
-  
+
   // get each successive byte on each call
   if(rxBufferIndex < rxBufferLength){
     value = rxBuffer[rxBufferIndex];
@@ -260,7 +260,7 @@ int TwoWire::read(void)
 int TwoWire::peek(void)
 {
   int value = -1;
-  
+
   if(rxBufferIndex < rxBufferLength){
     value = rxBuffer[rxBufferIndex];
   }
@@ -345,20 +345,20 @@ const uint8_t WIRE_BUFFER_LENGTH = TWI_BUFFER_SIZE - 1; //reserve slave addr
 
 // Initialize Class Variables //////////////////////////////////////////////////
 
-uint8_t *USIWire::Buffer = TWI_Buffer;
-uint8_t USIWire::BufferIndex = 0;
-uint8_t USIWire::BufferLength = 0;
+uint8_t *TwoWire::Buffer = TWI_Buffer;
+uint8_t TwoWire::BufferIndex = 0;
+uint8_t TwoWire::BufferLength = 0;
 
-uint8_t USIWire::transmitting = 0;
+uint8_t TwoWire::transmitting = 0;
 
 // Constructors ////////////////////////////////////////////////////////////////
 
-USIWire::USIWire() {
+TwoWire::TwoWire() {
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void USIWire::begin(void) {
+void TwoWire::begin(void) {
   BufferIndex = 0;
   BufferLength = 0;
 
@@ -367,24 +367,24 @@ void USIWire::begin(void) {
   USI_TWI_Master_Initialise();
 }
 
-void USIWire::begin(uint8_t address) {
+void TwoWire::begin(uint8_t address) {
   USI_TWI_Slave_Initialise(address);
 }
 
-void USIWire::begin(int address) {
+void TwoWire::begin(int address) {
   begin((uint8_t)address);
 }
 
-void USIWire::end(void) {
+void TwoWire::end(void) {
   USI_TWI_Slave_Disable();
 }
 
-void USIWire::setClock(uint32_t clock) {
+void TwoWire::setClock(uint32_t clock) {
   // XXX: to be implemented.
   (void)clock; //disable warning
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity,
                              uint32_t iaddress, uint8_t isize,
                              uint8_t sendStop) {
   if (isize > 0) {
@@ -430,25 +430,25 @@ uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
   return quantity - 1; // ignore slave address
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity,
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity,
                              uint8_t sendStop) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint32_t)0,
                      (uint8_t)0, (uint8_t)sendStop);
 }
 
-uint8_t USIWire::requestFrom(uint8_t address, uint8_t quantity) {
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
 }
 
-uint8_t USIWire::requestFrom(int address, int quantity) {
+uint8_t TwoWire::requestFrom(int address, int quantity) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
 }
 
-uint8_t USIWire::requestFrom(int address, int quantity, int sendStop) {
+uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
 }
 
-void USIWire::beginTransmission(uint8_t address) {
+void TwoWire::beginTransmission(uint8_t address) {
   // indicate that we are transmitting
   transmitting = 1;
   // set address of targeted slave and write mode
@@ -458,11 +458,11 @@ void USIWire::beginTransmission(uint8_t address) {
   BufferLength = BufferIndex;
 }
 
-void USIWire::beginTransmission(int address) {
+void TwoWire::beginTransmission(int address) {
   beginTransmission((uint8_t)address);
 }
 
-uint8_t USIWire::endTransmission(uint8_t sendStop) {
+uint8_t TwoWire::endTransmission(uint8_t sendStop) {
   // transmit buffer (blocking)
   uint8_t ret = USI_TWI_Start_Transceiver_With_Data_Stop(Buffer,
                                                          BufferLength,
@@ -487,14 +487,14 @@ uint8_t USIWire::endTransmission(uint8_t sendStop) {
   return 0; //success
 }
 
-uint8_t USIWire::endTransmission(void) {
+uint8_t TwoWire::endTransmission(void) {
   return endTransmission(true);
 }
 
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(uint8_t data) {
+size_t TwoWire::write(uint8_t data) {
   if (transmitting) { // in master transmitter mode
     // don't bother if buffer is full
     if (BufferLength >= TWI_BUFFER_SIZE) {
@@ -519,7 +519,7 @@ size_t USIWire::write(uint8_t data) {
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(const uint8_t *data, size_t quantity) {
+size_t TwoWire::write(const uint8_t *data, size_t quantity) {
   size_t numBytes = 0;
   for (size_t i = 0; i < quantity; ++i){
     numBytes += write(data[i]);
@@ -530,7 +530,7 @@ size_t USIWire::write(const uint8_t *data, size_t quantity) {
 // must be called in:
 // slave tx event callback
 // or after beginTransmission(address)
-size_t USIWire::write(const char *str) {
+size_t TwoWire::write(const char *str) {
   if (str == NULL) return 0;
   return write((const uint8_t *)str, strlen(str));
 }
@@ -538,7 +538,7 @@ size_t USIWire::write(const char *str) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::available(void) {
+int TwoWire::available(void) {
   if (BufferLength) {
     return BufferLength - BufferIndex;
   } else {
@@ -549,7 +549,7 @@ int USIWire::available(void) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::read(void) {
+int TwoWire::read(void) {
   int value = -1;
 
   // get each successive byte on each call
@@ -568,7 +568,7 @@ int USIWire::read(void) {
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-int USIWire::peek(void) {
+int TwoWire::peek(void) {
   int value = -1;
 
   if (available()) {
@@ -582,27 +582,27 @@ int USIWire::peek(void) {
   return value;
 }
 
-void USIWire::flush(void) {
+void TwoWire::flush(void) {
   // XXX: to be implemented.
 }
 
 // sets function called on slave write
-void USIWire::onReceive( void (*function)(int) ) {
+void TwoWire::onReceive( void (*function)(int) ) {
   USI_TWI_On_Slave_Receive = function;
 }
 
 // sets function called on slave read
-void USIWire::onRequest( void (*function)(void) ) {
+void TwoWire::onRequest( void (*function)(void) ) {
   USI_TWI_On_Slave_Transmit = function;
 }
 
 // return true on I2C/TWI activity
-uint8_t USIWire::isActive(void) {
+uint8_t TwoWire::isActive(void) {
   return USI_TWI_Slave_Is_Active();
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////s
-USIWire Wire = USIWire();
+TwoWire Wire = TwoWire();
 #else 
 #if defined(TWSD) && !defined(__AVR_ATtiny1634__)
 #include "TWSWire.h"

--- a/avr/libraries/Wire/src/Wire.h
+++ b/avr/libraries/Wire/src/Wire.h
@@ -97,7 +97,7 @@ extern const uint8_t WIRE_BUFFER_LENGTH;
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
-class USIWire {
+class TwoWire {
   private:
     static uint8_t *Buffer;
     static uint8_t BufferIndex;
@@ -105,7 +105,7 @@ class USIWire {
 
     static uint8_t transmitting;
   public:
-    USIWire();
+    TwoWire();
     void begin();
     void begin(uint8_t);
     void begin(int);
@@ -136,7 +136,7 @@ class USIWire {
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
 };
-extern USIWire Wire;
+extern TwoWire Wire;
 #endif
 #else
 #if defined(TWSD) && !defined(__AVR_ATtiny1634__)


### PR DESCRIPTION
see #238

I'm not sure if TWSWire should also be converted, the only board I have handy is an '84, which is USIWire. TwoWire is needed [for this library](https://github.com/sparkfun/SparkFun_SCD30_Arduino_Library/), and probably others that assume the class is named that or inherits from that.

Naturally, the only '84 I have (had) isn't talking to my ISP anymore. I'll have to build up a couple more.