### PR TITLE
Fix compile for ATTiny85 issue #244

### DIFF
--- a/avr/libraries/Wire/src/Wire.h
+++ b/avr/libraries/Wire/src/Wire.h
@@ -90,6 +90,7 @@ extern TwoWire Wire;
 #ifndef USIWire_h
 #define USIWire_h
 #include <inttypes.h>
+#include <stdio.h> // for size_t
 // Buffer sizes are defined in USI_TWI_Slave/USI_TWI_Slave.h
 extern const uint8_t WIRE_BUFFER_LENGTH;
 #define BUFFER_LENGTH (WIRE_BUFFER_LENGTH)


### PR DESCRIPTION
I'm not certain what led to previously working code using Wire.h for an ATTiny85 no longer compiling, but it happened after I upgraded the Arduino IDE to 1.8.7 from 1.8.5, so that included the "Updated toolchain to gcc 5.4.0".

I found other files including stdio.h "for size_t" such as Print.h included from Stream.h