### PR TITLE
Add Atmel ICE programmer entries

### DIFF
--- a/avr/avrdude.conf
+++ b/avr/avrdude.conf
@@ -967,6 +967,45 @@ programmer
   connection_type = usb;
 ;
 
+programmer
+  id    = "atmelice";
+  desc  = "Atmel-ICE (ARM/AVR) in JTAG mode";
+  type  = "jtagice3";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
+
+programmer
+  id    = "atmelice_pdi";
+  desc  = "Atmel-ICE (ARM/AVR) in PDI mode";
+  type  = "jtagice3_pdi";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
+
+programmer
+  id    = "atmelice_updi";
+  desc  = "Atmel-ICE (ARM/AVR) in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
+
+programmer
+  id    = "atmelice_dw";
+  desc  = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
+  type  = "jtagice3_dw";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
+
+programmer
+  id    = "atmelice_isp";
+  desc  = "Atmel-ICE (ARM/AVR) in ISP mode";
+  type  = "jtagice3_isp";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
 
 programmer
   id    = "pavr";


### PR DESCRIPTION
Copied the entries for Atmel ICE programmer from the avrdude.conf distributed with the Arduino IDE. A corresponding entry is not needed in programmers.txt as the Arduino IDE already shows an entry for the Atmel ICE - avrdude just doesn't know what to do with it as the entries are missing from the ATTinyCore avrdude.conf file.

This is working for me on Arduino IDE 1.8.6/1.8.7 with ATTinyCore release 1.2.0/1.2.1, programming and bootloading ATTiny85's with a Atmel ICE. 