### PR TITLE
Output disassembler listing during compilation

### DIFF
--- a/avr/create_disassembler_listing.sh
+++ b/avr/create_disassembler_listing.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+objdumpCommand="$1"
+options="$2"
+objfile="$3"
+outputFile="$4"
+
+"$objdumpCommand" $options "$objfile" > "$outputFile"

--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -30,6 +30,8 @@ compiler.ar.cmd=avr-{ltoarcmd}ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
+compiler.objdump.cmd=avr-objdump
+compiler.objdump.flags=--disassemble --source --line-numbers --demangle --section=.text
 compiler.elf2hex.flags=-O ihex -R .eeprom
 compiler.elf2hex.cmd=avr-objcopy
 compiler.ldflags=
@@ -71,6 +73,13 @@ recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.obj
 
 ## Create hex
 recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
+
+## Save disassembler listing
+recipe.hooks.objcopy.postobjcopy.1.pattern.windows=cmd /C "{compiler.path}{compiler.objdump.cmd}" {compiler.objdump.flags} "{build.path}/{build.project_name}.elf" > "{build.path}/{build.project_name}.lst"
+recipe.hooks.objcopy.postobjcopy.1.pattern.linux=chmod +x "{runtime.platform.path}/create_disassembler_listing.sh"
+recipe.hooks.objcopy.postobjcopy.1.pattern.macos=chmod +x "{runtime.platform.path}/create_disassembler_listing.sh"
+recipe.hooks.objcopy.postobjcopy.2.pattern.linux="{runtime.platform.path}/create_disassembler_listing.sh" "{compiler.path}{compiler.objdump.cmd}" "{compiler.objdump.flags}" "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.lst"
+recipe.hooks.objcopy.postobjcopy.2.pattern.macos="{runtime.platform.path}/create_disassembler_listing.sh" "{compiler.path}{compiler.objdump.cmd}" "{compiler.objdump.flags}" "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.lst"
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
Save a disassembler listing to the build folder.

Unresolved items:
- [ ] macOS testing (I have tested on Windows and Linux)
- [ ] What are the preferred avr-objdump options? I have used `--disassemble --source --line-numbers --demangle --section=.text`. This is based on the recommendation of [a random tutorial](https://www.megunolink.com/articles/how-to-detect-lockups-using-the-arduino-watchdog/) that started me using avr-objdump, with the addition of `--line-numbers` (which I think is helpful) and `--demangle` (because it sounds useful from the avr-objdump documentation).
- [ ] Should the output filename extension be .lss instead of .lst? [This](https://www.avrfreaks.net/forum/whats-diff-lss-lst-file) indicates .lst is assembler listing and .lss is disassembler listing, in which case it should be changed to .lss.

I was forced to add an external script for Linux (and macOS as well, I assume). I originally had intended to pass the command to `sh -c`, similar to how I did it for Windows. However, the `sh -c` argument must be quoted, as well as the paths inside the command (to support spaces in paths), and the Arduino IDE does some strange mangling of the quotes in the command in an attempt to be "helpful", which breaks it.

Resolves https://github.com/SpenceKonde/ATTinyCore/issues/86