### PR TITLE
Quote paths in save hex recipes

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -88,11 +88,11 @@ recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
 ## Save hex
-recipe.hooks.savehex.presavehex.1.pattern.windows={runtime.platform.path}/delete_merged_output.bat {build.export_merged_output} "{build.path}\{build.project_name}.with_bootloader.hex"
-recipe.hooks.savehex.presavehex.1.pattern.linux=chmod +x {runtime.platform.path}/delete_merged_output.sh
-recipe.hooks.savehex.presavehex.1.pattern.macosx=chmod +x {runtime.platform.path}/delete_merged_output.sh
-recipe.hooks.savehex.presavehex.2.pattern.linux={runtime.platform.path}/delete_merged_output.sh {build.export_merged_output} "{build.path}/{build.project_name}.with_bootloader.hex"
-recipe.hooks.savehex.presavehex.2.pattern.macosx={runtime.platform.path}/delete_merged_output.sh {build.export_merged_output} "{build.path}/{build.project_name}.with_bootloader.hex"
+recipe.hooks.savehex.presavehex.1.pattern.windows="{runtime.platform.path}/delete_merged_output.bat" {build.export_merged_output} "{build.path}\{build.project_name}.with_bootloader.hex"
+recipe.hooks.savehex.presavehex.1.pattern.linux=chmod +x "{runtime.platform.path}/delete_merged_output.sh"
+recipe.hooks.savehex.presavehex.1.pattern.macosx=chmod +x "{runtime.platform.path}/delete_merged_output.sh"
+recipe.hooks.savehex.presavehex.2.pattern.linux="{runtime.platform.path}/delete_merged_output.sh" {build.export_merged_output} "{build.path}/{build.project_name}.with_bootloader.hex"
+recipe.hooks.savehex.presavehex.2.pattern.macosx="{runtime.platform.path}/delete_merged_output.sh" {build.export_merged_output} "{build.path}/{build.project_name}.with_bootloader.hex"
 recipe.output.tmp_file={build.project_name}.hex
 recipe.output.save_file={build.project_name}.hex
 


### PR DESCRIPTION
Previously, **Sketch > Export Compiled Binary** would fail when run on a Linux system (and likely macOS as well) with ATTinyCore installed to a path that contained a space.