### PR TITLE
Fixes DI and DO pins on attiny861

### DIFF
--- a/avr/variants/tinyX61/pins_arduino.h
+++ b/avr/variants/tinyX61/pins_arduino.h
@@ -50,8 +50,8 @@
 #define USI_DDR_PORT DDRB
 #define USI_SCK_PORT DDRB
 #define USCK_DD_PIN DDB2
-#define DO_DD_PIN DDB0
-#define DI_DD_PIN DDB1
+#define DO_DD_PIN DDB1
+#define DI_DD_PIN DDB0
 #  define DDR_USI DDRB
 #  define PORT_USI PORTB
 #  define PIN_USI PINB


### PR DESCRIPTION
According to the attiny861 [datasheet](http://ww1.microchip.com/downloads/en/devicedoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf) DI is pin PB0 and DO is PB1.

Fixes issue #282