### PR TITLE
Add 24MHz support for micros()

### DIFF
--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -216,17 +216,14 @@ unsigned long micros()
 
 
 #if F_CPU < 1000000L
-return ((m << 8) + t) * MillisTimer_Prescale_Value * (1000000L/F_CPU);
+  return ((m << 8) + t) * MillisTimer_Prescale_Value * (1000000L/F_CPU);
 #else
-#if (MillisTimer_Prescale_Value % clockCyclesPerMicrosecond() == 0 ) //Can we just do it the naive way? If so great!
+#if (MillisTimer_Prescale_Value % clockCyclesPerMicrosecond() == 0 ) // Can we just do it the naive way? If so great!
   return ((m << 8) + t) * (MillisTimer_Prescale_Value / clockCyclesPerMicrosecond());
-//Otherwise we have a problem.
-#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 11) // 5.75 vs real value 5.818 (11mhz) 5.78 (11.059)
-  m=(m << 8) + t;
-  return m+(m<<2)+(m>>1)+(m>>2);
-#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 12) // 5.3125 vs real value 5.333
-  m=(m << 8) + t;
-  return m+(m<<2)+(m>>2)+(m>>4);
+  // Otherwise we do clock-specific calculations
+#elif (MillisTimer_Prescale_Value == 64 && F_CPU == 24000000L) // 2.6875 vs real value 2.67 
+  m = (m << 8) + t;
+  return (m<<1) + (m >> 1) + (m >> 3) + (m >> 4); // multiply by 2.6875
 #elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 20) // 3.187 vs real value 3.2
   m=(m << 8) + t;
   return m+(m<<1)+(m>>2)-(m>>4);
@@ -239,13 +236,19 @@ return ((m << 8) + t) * MillisTimer_Prescale_Value * (1000000L/F_CPU);
 #elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 14) //4.5 - actual 4.57 for 14.0mhz, 4.47 for the 14.3 crystals scrappable from everything
   m=(m << 8) + t;
   return (m<<2)+(m>>1);
-#elif (MillisTimer_Prescale_Value == 64 && F_CPU==7372800L) //8.625, vs real value 8.68
+#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 12) // 5.3125 vs real value 5.333
+  m=(m << 8) + t;
+  return m+(m<<2)+(m>>2)+(m>>4);
+#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 11) // 5.75 vs real value 5.818 (11mhz) 5.78 (11.059)
+  m=(m << 8) + t;
+  return m+(m<<2)+(m>>1)+(m>>2);
+#elif (MillisTimer_Prescale_Value == 64 && F_CPU==7372800L) // 8.625, vs real value 8.68
   m=(m << 8) + t;
   return (m<<3)+(m>>2)+(m>>3);
-#elif (MillisTimer_Prescale_Value == 64 && F_CPU==6000000L) //10.625, vs real value 10.67
+#elif (MillisTimer_Prescale_Value == 64 && F_CPU==6000000L) // 10.625, vs real value 10.67
   m=(m << 8) + t;
   return (m<<3)+(m<<1)+(m>>2)+(m>>3);
-#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 9) //for 9mhz, this is a little off, but for 9.21, it's very close!
+#elif (MillisTimer_Prescale_Value == 64 && clockCyclesPerMicrosecond() == 9) // For 9mhz, this is a little off, but for 9.21, it's very close!
   return ((m << 8) + t) * (MillisTimer_Prescale_Value / clockCyclesPerMicrosecond());
 #else
   //return ((m << 8) + t) * (MillisTimer_Prescale_Value / clockCyclesPerMicrosecond());
@@ -257,13 +260,8 @@ return ((m << 8) + t) * MillisTimer_Prescale_Value * (1000000L/F_CPU);
   //the high part gets divided by cCPuS then multiplied by the prescaler. Then take the low 8 bits plus the high part modulo-cCPuS to correct for the division, then multiply that by the prescaler value first before dividing by cCPuS, and finally add the two together.
   //return ((m << 8 )/clockCyclesPerMicrosecond()* MillisTimer_Prescale_Value) + ((t+(((m<<8)%clockCyclesPerMicrosecond())) * MillisTimer_Prescale_Value / clockCyclesPerMicrosecond()));
   return ((m << 8 )/clockCyclesPerMicrosecond()* MillisTimer_Prescale_Value) + (t * MillisTimer_Prescale_Value / clockCyclesPerMicrosecond());
-  
-  //This doesn't work, and I don't know why:
-  //return ((m*(unsigned long)MillisTimer_Prescale_Value / (unsigned long)clockCyclesPerMicrosecond())<<8)+(((unsigned long)t+((m%11)<<8)) * (unsigned long)MillisTimer_Prescale_Value / (unsigned long)clockCyclesPerMicrosecond());
-  //This works without the loss of precision, but eats an extra 380 bytes of flash
-  //return (((long long)((m << 8) + t)) * MillisTimer_Prescale_Value / clockCyclesPerMicrosecond()); //very disappointing fix, eats an extra 380 bytes of flash because of long long
 #endif
-  #endif
+#endif
 }
 
 


### PR DESCRIPTION
While I'm at it, I also added accurate micros() for 24MHz for people who need the last bit of speed out of their microcontrollers. I also cleaned up the micros() function a bit, if it's okay. I ordered the frequencies correctly in descending order and removed some old comments or replaced them.