### PR TITLE
Remove trailing whitespace

### DIFF
--- a/ChangesNotInBoardManagerYet.md
+++ b/ChangesNotInBoardManagerYet.md
@@ -6,4 +6,4 @@
 * Correct issues with some of the macros for t43.
 * Add missing attiny85 9.26MHz external clock menu option.
 * Fix PWM on pins A3 and A6 on Tiny841/441 (#302)
-* Correct hardware specs for Tiny24/44/84 and Tiny1634 (#304/305). 
+* Correct hardware specs for Tiny24/44/84 and Tiny1634 (#304/305).

--- a/avr/extras/ATtiny_x8.md
+++ b/avr/extras/ATtiny_x8.md
@@ -20,12 +20,12 @@ The ATtiny x8 series is intended as a low cost option compatible with the popula
 ### Optiboot Bootloader
 This core includes an Optiboot bootloader for the ATtiny88/48, operating using software serial at 19200 baud - the software serial uses the AIN0 and AIN1 pins (see UART section below). The bootloader uses 640b of space, leaving 3456 or7552b available for user code. In order to work on the 88, which does not have hardware bootloader support (hence no BOOTRST functionality), "Virtual Boot" is used. This works around this limitation by rewriting the vector table of the sketch as it's uploaded - the reset vector gets pointed at the start of the bootloader, while the EE_RDY vector gets pointed to the start of the application.
 
-Programming the ATTiny88/48 via ISP without the bootloader is fully supported. 
+Programming the ATTiny88/48 via ISP without the bootloader is fully supported.
 
 ### Clock options
-The ATtiny x8 series of microcontrollers, in the interest of lowering costs, does not provide support for using an external crystal as a clock source, only the internal oscillator (at ~8 or ~1mhz) or an external *clock* source. The internal oscillator is only factory calibrated to +/- 10%, so for timing critical tasks, other arrangements (or a different chip) must be used. Note that using an external clock source is not an option in the board drop-down menus, so you cannot set it that way with "burn bootloader" from within the IDE - you must do it manually (this is to prevent new users from accidentally bricking their parts). 
+The ATtiny x8 series of microcontrollers, in the interest of lowering costs, does not provide support for using an external crystal as a clock source, only the internal oscillator (at ~8 or ~1mhz) or an external *clock* source. The internal oscillator is only factory calibrated to +/- 10%, so for timing critical tasks, other arrangements (or a different chip) must be used. Note that using an external clock source is not an option in the board drop-down menus, so you cannot set it that way with "burn bootloader" from within the IDE - you must do it manually (this is to prevent new users from accidentally bricking their parts).
 
-While the +/- 10% accuracy is not close enough to guarantee UART serial will work (that requires ~2% accuracy), every chip I have tested at room temperature and 3.3 ~ 5v has been close enough to 8MHz for serial to work without calibration. 
+While the +/- 10% accuracy is not close enough to guarantee UART serial will work (that requires ~2% accuracy), every chip I have tested at room temperature and 3.3 ~ 5v has been close enough to 8MHz for serial to work without calibration.
 
 ### I2C Support
 There is full Hardware I2C support using Wire.h


### PR DESCRIPTION
The trailing whitespace introduced in recent commits causes the Travis CI build to fail.