### PR TITLE
Add Diamex USB-ISP to programmers.txt

### DIFF
--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -6,6 +6,14 @@ avrisp.program.protocol=stk500v1
 avrisp.program.tool=avrdude
 avrisp.program.extra_params=-P{serial.port}
 
+diamexusbisp.name=Diamex USB ISP (ATTinyCore)
+diamexusbisp.communication=serial
+diamexusbisp.protocol=stk500v2
+diamexusbisp.program.tool=avrdude
+diamexusbisp.program.protocol=stk500v2
+diamexusbisp.program.tool=avrdude
+diamexusbisp.program.extra_params=-P{serial.port}
+
 avrispmkii.name=AVRISP mkII (ATTinyCore)
 avrispmkii.communication=usb
 avrispmkii.protocol=stk500v2


### PR DESCRIPTION
Include the DIAMEX USB-ISP. Typically sold in Germany by ELV. 
The programmer uses the STK500V2 protocol but requires to set the serial port. 

See:
 * https://de.elv.com/diamex-usb-isp-programmer-inkl-6-auf-10-adapter-und-10-poliges-flachbandkabel-106983
 * https://de.elv.com/diamex-usb-isp-programmer-102665?fs=2327143309
 * https://www.diamex.de/dxshop/DIAMEX-USB-ISP-Programmer-Stick-fuer-AVR