### PR TITLE
Add printf to print class

### DIFF
--- a/avr/cores/tiny/Print.cpp
+++ b/avr/cores/tiny/Print.cpp
@@ -200,6 +200,23 @@ size_t Print::println( fstr_t* s )
   return( n );
 }
 
+static int16_t printf_putchar(char c, FILE *fp)
+{
+  ((class Print *)(fdev_get_udata(fp)))->write((uint8_t)c);
+  return 0;
+}
+
+int16_t Print::printf(const char *ifsh, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, ifsh);
+  return vfprintf(&f, ifsh, ap);
+}
+
 #ifdef FLASHSTRING_SUPPORT
 
 size_t Print::print(const __FlashStringHelper *ifsh)
@@ -220,6 +237,17 @@ size_t Print::println(const __FlashStringHelper *ifsh)
   size_t n = print(ifsh);
   n += println();
   return n;
+}
+
+int16_t Print::printf(const __FlashStringHelper *ifsh, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, ifsh);
+  return vfprintf_P(&f, (const char *)ifsh, ap);
 }
 
 #endif

--- a/avr/cores/tiny/Print.h
+++ b/avr/cores/tiny/Print.h
@@ -106,9 +106,12 @@ class Print
     size_t println(double, int = 2);
     size_t println(void);
 
+    int16_t printf(const char *ifsh, ...);
+
     #ifdef FLASHSTRING_SUPPORT
     size_t print(const __FlashStringHelper *ifsh);
     size_t println(const __FlashStringHelper *ifsh);
+    int16_t printf(const __FlashStringHelper *ifsh, ...);
     #endif
 };
 

--- a/avr/cores/tinymodern/Print.cpp
+++ b/avr/cores/tinymodern/Print.cpp
@@ -197,6 +197,34 @@ size_t Print::println(const Printable& x)
   return n;
 }
 
+static int16_t printf_putchar(char c, FILE *fp)
+{
+  ((class Print *)(fdev_get_udata(fp)))->write((uint8_t)c);
+  return 0;
+}
+
+int16_t Print::printf(const char *ifsh, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, ifsh);
+  return vfprintf(&f, ifsh, ap);
+}
+
+int16_t Print::printf(const __FlashStringHelper *ifsh, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, ifsh);
+  return vfprintf_P(&f, (const char *)ifsh, ap);
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base) {

--- a/avr/cores/tinymodern/Print.h
+++ b/avr/cores/tinymodern/Print.h
@@ -79,6 +79,9 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    int16_t printf(const char *ifsh, ...);
+    int16_t printf(const __FlashStringHelper *ifsh, ...);
 };
 
 #endif


### PR DESCRIPTION
Even though it's a bit memory hungry (occupies about 2kB), printf is super useful on microcontrollers with a bit more flash memory, suck as ATtiny167 and ATtiny1634.

This PR adds printf to the print class, which means that it will be available for all libraries that inherits Print. This includes Serial, SoftwareSerial, LiquidCrystal, and other GLCD libraries such as U8G2.

Even though the Arduino developers refuse to implement this in the official cores, you'll find printf implemented in all Adafruits cores, Teensy, ESP8266/ESP32, and all my Ardunio cores as well.

If this is something you will accept, I can create a PR for megaTinyCore as well.