### PR TITLE
Deleted line "#define TUNED_OSCCAL_VALUE OSCCAL"

### DIFF
--- a/avr/variants/tiny43/pins_arduino.h
+++ b/avr/variants/tiny43/pins_arduino.h
@@ -101,8 +101,7 @@ static const uint8_t A3 = 0x80 | 3;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX313/pins_arduino.h
+++ b/avr/variants/tinyX313/pins_arduino.h
@@ -73,8 +73,7 @@ static const uint8_t SCL = 16;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX4/pins_arduino.h
+++ b/avr/variants/tinyX4/pins_arduino.h
@@ -102,8 +102,7 @@ static const uint8_t A7 = 0x80 | 7;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX4_reverse/pins_arduino.h
+++ b/avr/variants/tinyX4_reverse/pins_arduino.h
@@ -102,8 +102,7 @@ static const uint8_t A7 = 0x80 | 7;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX5/pins_arduino.h
+++ b/avr/variants/tinyX5/pins_arduino.h
@@ -91,8 +91,7 @@ static const uint8_t A3 = 0x80 | 3;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX61/pins_arduino.h
+++ b/avr/variants/tinyX61/pins_arduino.h
@@ -107,8 +107,7 @@ static const uint8_t A10 = 0x80 | 10;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX7/pins_arduino.h
+++ b/avr/variants/tinyX7/pins_arduino.h
@@ -86,8 +86,7 @@ static const uint8_t A10 = 0x80 | 10;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX7_New/pins_arduino.h
+++ b/avr/variants/tinyX7_New/pins_arduino.h
@@ -108,8 +108,7 @@ static const uint8_t A10 = 0x80 | 10;
 //Core Configuration (used to be in core_build_options.h)
 
 //If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
-//Change the value here with the tuned value. By default this option uses the default value which the compiler will optimise out.
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//Change the value here with the tuned value.
 //e.g
 //#define TUNED_OSCCAL_VALUE                        0x57
 

--- a/avr/variants/tinyX8/pins_arduino.h
+++ b/avr/variants/tinyX8/pins_arduino.h
@@ -31,7 +31,10 @@
 
 #include <avr/pgmspace.h>
 
-#define TUNED_OSCCAL_VALUE                        OSCCAL
+//If Software Serial communications doesn't work, run the TinyTuner sketch provided with the core to give you a calibrated OSCCAL value.
+//Change the value here with the tuned value.
+//e.g
+//#define TUNED_OSCCAL_VALUE                        0x57
 
 #define ADC_TEMPERATURE 8
 


### PR DESCRIPTION
Hello,
while looking at the compiled result I found that the current compiler does not optimize out the statement.
Instead it generates this nonsense:
```
  #ifdef TUNED_OSCCAL_VALUE
  OSCCAL = TUNED_OSCCAL_VALUE; //set the oscillator calibration value based on the pins_arduino.h file. If this is not set, it will be optimised away
     b06:	81 b7      	in	r24, 0x31	; 49
     b08:	81 bf       	out	0x31, r24	; 49
```

Using  `#if (TUNED_OSCCAL_VALUE != OSCCAL)` in main.cpp leads to:
`error: operator '*' has no left operand`
so I must delete the line in every pins_arduino.h file.

Best regards
Armin
