### PR TITLE
Fix reading after switch from master to slave

### DIFF
--- a/avr/libraries/Wire/src/Wire.cpp
+++ b/avr/libraries/Wire/src/Wire.cpp
@@ -370,7 +370,7 @@ void TwoWire::begin(void) {
 void TwoWire::begin(uint8_t address) {
   BufferIndex = 0;
   BufferLength = 0;
-  
+
   USI_TWI_Slave_Initialise(address);
 }
 

--- a/avr/libraries/Wire/src/Wire.cpp
+++ b/avr/libraries/Wire/src/Wire.cpp
@@ -368,6 +368,9 @@ void TwoWire::begin(void) {
 }
 
 void TwoWire::begin(uint8_t address) {
+  BufferIndex = 0;
+  BufferLength = 0;
+  
   USI_TWI_Slave_Initialise(address);
 }
 


### PR DESCRIPTION
The read function on devices with USI  always returned -1 (signed) / 255 (unsigned), when reading in slave mode after requestFrom and switching from master mode to slave mode, because the BufferLength was not set to 0 when starting in the slave mode, this fixes the problem.