### PR TITLE
Allow disabling Timer1 and ADC init on tinyX5.

### DIFF
--- a/avr/variants/tinyX5/pins_arduino.h
+++ b/avr/variants/tinyX5/pins_arduino.h
@@ -103,8 +103,12 @@ static const uint8_t A3 = 0x80 | 3;
 
 
 //Choosing not to initialise saves power and flash. 1 = initialise.
-#define INITIALIZE_ANALOG_TO_DIGITAL_CONVERTER    1
-#define INITIALIZE_SECONDARY_TIMERS               1
+#ifndef INITIALIZE_ANALOG_TO_DIGITAL_CONVERTER
+  #define INITIALIZE_ANALOG_TO_DIGITAL_CONVERTER    1
+#endif
+#ifndef INITIALIZE_SECONDARY_TIMERS
+  #define INITIALIZE_SECONDARY_TIMERS               1
+#endif
 /*
   For various reasons, Timer 0 is a better choice for the millis timer on the
   '85 processor.


### PR DESCRIPTION
Proposed implementation of 480 for tinyX5.  I'm not using other cores, but poking around it looks like tinyX313 already has code like this and tiny43, X4, X61, X7, and X8 could probably use the same treatment.  For #480.