### PR TITLE
Accurate delayMicroseconds for odd frequencies

### DIFF
--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -445,9 +445,9 @@ void delayMicroseconds(unsigned int us)
     us = (us << 1) + us; // x3 us, = 5 cycles
 
     // account for the time taken in the preceding commands.
-    // we just burned 20 (22) cycles above, remove 3 (3*6=18),
-    // us is at least 6 so we may subtract 3
-    us -= 3; // = 2 cycles
+    // we burned 20 (22) cycles above, plus 2 more below, remove 4 (4*6=24),
+    // us is at least 6 so we may subtract 4
+    us -= 4; // = 2 cycles
 
   #elif F_CPU >= 16500000L
     // for the special 16.5 MHz clock
@@ -461,7 +461,7 @@ void delayMicroseconds(unsigned int us)
     us = (us << 2) + (us >> 3); // x4.125 with 23 cycles
 
     // account for the time taken in the preceding commands.
-    // we just burned 38 (40) cycles above, remove 10, (4*10=40)
+    // we burned 38 (40) cycles above, plus 2 below, remove 10 (4*10=40)
     // us is at least 8, so we subtract only 7 to keep it positive
     // the error is below one microsecond and not worth extra code
     us -= 7; // = 2 cycles

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -580,6 +580,22 @@ void delayMicroseconds(unsigned int us)
     // so remove 5 (5 * 4 = 20), but we may at most remove 4 to keep us > 0.
     us -= 4; // = 2 cycles
 
+  #elif F_CPU >= 2000000L
+    // for that unusual 2mhz clock...
+
+    // for a 1 to 9 microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 8us
+    if (us <= 9) return; //  = 3 cycles, (4 when true)
+    // must be at least 10 if we want to do /= 2 -= 4
+
+    // divide by 2 to account for 2us runtime per loop iteration
+    us >>= 1; // = 2 cycles;
+
+    // the following loop takes 2 microseconds (4 cycles) per iteration
+    // we burned 17 (19) above plus 2 below,
+    // so remove 5 (5 * 4 = 20), but we may at most remove 4 to keep us > 0.
+    us -= 4; // = 2 cycles
+
   #else
     // for the 1 MHz internal clock (default settings for common AVR microcontrollers)
     // the overhead of the function calls is 14 (16) cycles

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -444,7 +444,7 @@ void delayMicroseconds(unsigned int us)
     // so execute it three times for each microsecond of delay requested.
     us = (us << 1) + us; // x3 us, = 5 cycles
 
-    // account for the time taken in the preceeding commands.
+    // account for the time taken in the preceding commands.
     // we just burned 20 (22) cycles above, remove 3 (3*6=18),
     // us is at least 6 so we may subtract 3
     us -= 3; // = 2 cycles

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -521,7 +521,7 @@ void delayMicroseconds(unsigned int us)
     // for the 12 MHz clock if somebody is working with USB
 
     // for a 1 microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 1.5us
+    // of the function call takes 14 (16) cycles, which is 1.3us
     if (us <= 1) return; //  = 3 cycles, (4 when true)
 
     // the following loop takes 1/3 of a microsecond (4 cycles)
@@ -550,30 +550,35 @@ void delayMicroseconds(unsigned int us)
     // we just burned 17 (19) cycles above, remove 4, (4*4=16)
     // us is at least 6 so we can subtract 4
     us -= 4; // = 2 cycles
+
   #elif F_CPU >= 6000000L
     // for that unusual 6mhz clock...
 
-    // for a 1 and 2 microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 2us
-    if (us <= 2) return; //  = 3 cycles, (4 when true)
+    // for a 1 to 3 microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 2.5us
+    if (us <= 3) return; //  = 3 cycles, (4 when true)
 
-    // the following loop takes 2/3rd microsecond (4 cycles)
-    // per iteration, so we want to add it to half of itself
-    us +=us>>1;
-    us -= 2; // = 2 cycles
+    // make the loop below last 6 cycles
+  #undef  _MORENOP_
+  #define _MORENOP_ " nop \n\t  nop \n\t"
+
+    // the following loop takes 1 microsecond (6 cycles) per iteration
+    // we burned 15 (17) cycles above, plus 2 below, remove 3 (3 * 6 = 18)
+    // us is at least 4 so we can subtract 3
+    us -= 3; // = 2 cycles
 
   #elif F_CPU >= 4000000L
     // for that unusual 4mhz clock...
 
-    // for a 1 and 2 microsecond delay, simply return.  the overhead
-    // of the function call takes 14 (16) cycles, which is 2us
-    if (us <= 2) return; //  = 3 cycles, (4 when true)
+    // for a 1 to 4 microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is 4us
+    if (us <= 4) return; //  = 3 cycles, (4 when true)
 
     // the following loop takes 1 microsecond (4 cycles)
     // per iteration, so nothing to do here! \o/
-
-    us -= 2; // = 2 cycles
-
+    // ... in terms of rescaling.  We burned 15 (17) above plus 2 below,
+    // so remove 5 (5 * 4 = 20), but we may at most remove 4 to keep us > 0.
+    us -= 4; // = 2 cycles
 
   #else
     // for the 1 MHz internal clock (default settings for common AVR microcontrollers)

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -449,6 +449,23 @@ void delayMicroseconds(unsigned int us)
     // us is at least 6 so we may subtract 3
     us -= 3; // = 2 cycles
 
+  #elif F_CPU >= 16500000L
+    // for the special 16.5 MHz clock
+
+    // for a one-microsecond delay, simply return.  the overhead
+    // of the function call takes 14 (16) cycles, which is about 1us
+    if (us <= 1) return; //  = 3 cycles, (4 when true)
+
+    // the following loop takes 1/4 of a microsecond (4 cycles) times 32./33.
+    // per iteration, thus rescale us by 4. * 33. / 32. = 4.125 to compensate
+    us = (us << 2) + (us >> 3); // x4.125 with 23 cycles
+
+    // account for the time taken in the preceding commands.
+    // we just burned 38 (40) cycles above, remove 10, (4*10=40)
+    // us is at least 8, so we subtract only 7 to keep it positive
+    // the error is below one microsecond and not worth extra code
+    us -= 7; // = 2 cycles
+
   #elif F_CPU >= 16000000L
     // for the 16 MHz clock on most Arduino boards
 


### PR DESCRIPTION
Hi, just added delayMicroseconds for 18 MHz, which I'm currently using to overclock my tiny45.

What would be your opinion on the 18.432 MHz case, replacing the shifts
```c
    us = (us >> 1) + (us >> 2) + (us >> 3) + (us >> 4);
```
with the accurate long multiply
```c
    us = (us * 60398UL) >> 16; 
```
and adjusting the number of cycles used in calculating? (Not my idea, this is e.g. in MiniCore.)