### PR TITLE
Correct micros() to zero long-term drift

### DIFF
--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -311,7 +311,7 @@ static void initToneTimerInternal(void);
     unsigned char f = millis_timer_fract;
 #ifdef CORRECT_EXACT_MILLIS
     static unsigned char correct_exact = 0;     // rollover intended
-    if (++correct_exact <= CORRECT_EXACT_MANY) {
+    if (++correct_exact < CORRECT_EXACT_MANY) {
       ++f;
     }
 #endif

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -402,11 +402,14 @@ static void initToneTimerInternal(void);
   #ifdef CORRECT_EXACT_MICROS
     /* We convert milliseconds, fractional part and timer value
        into a microsecond value.  Relies on CORRECT_EXACT_MILLIS. */
+    m = (((m << 7) - (m << 1) - m + f) << 3) + ((
+    #if F_CPU == 16500000L // special purpose faster correction
+        ((unsigned int) t << 8) - ((unsigned int) t << 3)
+    #else // general catch-all case
     #if !defined CORRECT_BITS || !defined CORRECT_BIT7
     #error "micros() correction relies on bit 7 to be defined"
     #endif
-    m = (((m << 7) - (m << 1) - m + f) << 3) + (
-      ( ((unsigned int) t << 7)
+        ((unsigned int) t << 7)
     #ifdef CORRECT_BIT6
       + ((unsigned int) t << 6)
     #endif
@@ -419,6 +422,7 @@ static void initToneTimerInternal(void);
     #ifdef CORRECT_BIT3
       + ((unsigned int) t << 3)
     #endif
+    #endif // general case
       ) >> (8 - CORRECT_BITS));
     return q ? m + MICROSECONDS_PER_MILLIS_OVERFLOW : m;
   #else

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -140,7 +140,8 @@
    it precisely follows the oscillator used for timing.
 
    When it has a fractional part that leads to an error when ignored,
-   we apply a correction.  This correction yields a drift below 4 ppm.
+   we apply a correction.  This correction yields a drift of 30 ppm or less:
+   1e6 / (512 * (minimum_MICROSECONDS_PER_MILLIS_OVERFLOW >> 3)) <= 30.
 
    The mathematics of the correction are coded in the preprocessor and
    produce compile-time constants that do not affect size or run time.

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -418,14 +418,11 @@ static void initToneTimerInternal(void);
        For the timer we just need to be close from below.
        Must never be too high, or micros jumps backwards. */
     m = (((m << 7) - (m << 1) - m + f) << 3) + ((
-    /* Of the hand-tuned corrected frequencies, 18.432, 18, 16.5, 9.216 MHz
-       have the highest possible accuracy concerning the timer counter,
-       at the same time being cheaper than most other odd frequencies. */
     #if   F_CPU == 24000000L || F_CPU == 12000000L || F_CPU == 6000000L // 1360, 680
         (r = ((unsigned int) t << 7) + ((unsigned int) t << 5), r + (r >> 4))
     #elif F_CPU == 22118400L || F_CPU == 11059200L // 1472, 736
         ((unsigned int) t << 8) - ((unsigned int) t << 6) - ((unsigned int) t << 3)
-    #elif F_CPU == 20000000L // 816
+    #elif F_CPU == 20000000L || F_CPU == 10000000L // 816, 408
         (r = ((unsigned int) t << 8) - ((unsigned int) t << 6), r + (r >> 4))
     #elif F_CPU == 18432000L || F_CPU == 9216000L // 888, 444, etc.
         ((unsigned int) t << 8) - ((unsigned int) t << 5) - ((unsigned int) t << 1)

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -412,7 +412,11 @@ static void initToneTimerInternal(void);
     /* Of the hand-tuned corrected frequencies, 18.432, 18, 16.5, 9.216 MHz
        have the highest possible accuracy concerning the timer counter,
        at the same time being cheaper than most other odd frequencies. */
-    #if   F_CPU == 20000000L // hand-tuned correction: 816
+    #if   F_CPU == 24000000L || F_CPU == 12000000L || F_CPU == 6000000L // 1360, 680
+        (r = ((unsigned int) t << 7) + ((unsigned int) t << 5), r + (r >> 4))
+    #elif F_CPU == 22118400L || F_CPU == 11059200L // 1472, 736
+        ((unsigned int) t << 8) - ((unsigned int) t << 6) - ((unsigned int) t << 3)
+    #elif F_CPU == 20000000L // 816
         (r = ((unsigned int) t << 8) - ((unsigned int) t << 6), r + (r >> 4))
     #elif F_CPU == 18432000L || F_CPU == 9216000L // 888, 444, etc.
         ((unsigned int) t << 8) - ((unsigned int) t << 5) - ((unsigned int) t << 1)
@@ -420,12 +424,8 @@ static void initToneTimerInternal(void);
         (r = ((unsigned int) t << 8) - ((unsigned int) t << 5), r + (r >> 6))
     #elif F_CPU == 16500000L // hand-tuned correction: 992
         ((unsigned int) t << 8) - ((unsigned int) t << 3)
-    #elif F_CPU == 14745600L || F_CPU == 7372800L // 1104, 552
+    #elif F_CPU == 14745600L || F_CPU == 7372800L || F_CPU == 3686400L // 1104, 552
         ((unsigned int) t << 7) + ((unsigned int) t << 3) + ((unsigned int) t << 1)
-    #elif F_CPU == 12000000L || F_CPU == 6000000L // 1360, 680
-        (r = ((unsigned int) t << 7) + ((unsigned int) t << 5), r + (r >> 4))
-    #elif F_CPU == 11059200L // hand-tuned correction: 1472, 736
-        ((unsigned int) t << 8) - ((unsigned int) t << 6) - ((unsigned int) t << 3)
     #else // general catch-all
     #if !defined CORRECT_BITS || !defined CORRECT_BIT7
     #error "micros() correction relies on bit 7 to be defined"

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -241,9 +241,14 @@
 #if (USPEROF_BYTE & (1U << 4))
 #define CORRECT_BIT4
 #endif
-/* The bits below 4 are ignored for an error of at most 1 in 32.
-   This error affects micros() short-term jitter only.
-   Its long-term drift remains at zero. */
+#if (USPEROF_BYTE & (1U << 3))
+#define CORRECT_BIT3
+#endif
+/* The bits below 3 are ignored for a worst case jitter of 1 in 16.
+   This refers to micros() jitter during one timer cycle, meaning
+   that the increasing TCNT may be underestimated by this ratio.
+   The error resets to zero at the beginning of each cycle.
+   The long-term drift of micros() thus remains zero. */
 #endif // CORRECT_BITS
 #endif // CORRECT_EXACT_MICROS
 
@@ -410,6 +415,9 @@ static void initToneTimerInternal(void);
     #endif
     #ifdef CORRECT_BIT4
       + ((unsigned int) t << 4)
+    #endif
+    #ifdef CORRECT_BIT3
+      + ((unsigned int) t << 3)
     #endif
       ) >> (8 - CORRECT_BITS));
     return q ? m + MICROSECONDS_PER_MILLIS_OVERFLOW : m;

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -403,22 +403,24 @@ static void initToneTimerInternal(void);
   #ifdef CORRECT_EXACT_MICROS
     /* We convert milliseconds, fractional part and timer value
        into a microsecond value.  Relies on CORRECT_EXACT_MILLIS.
+       Basically we multiply by 1000 and add the scaled timer.
+
        The leading part by m and f is long-term accurate.
        For the timer we just need to be close from below.
        Must never be too high, or micros jumps backwards. */
     m = (((m << 7) - (m << 1) - m + f) << 3) + ((
-    /* Of the hand-tuned corrected frequencies, 18.432, 18 and 16.5 MHz
+    /* Of the hand-tuned corrected frequencies, 18.432, 18, 16.5, 9.216 MHz
        have the highest possible accuracy concerning the timer counter,
        at the same time being cheaper than most other odd frequencies. */
     #if   F_CPU == 20000000L // hand-tuned correction: 816
         (r = ((unsigned int) t << 8) - ((unsigned int) t << 6), r + (r >> 4))
-    #elif F_CPU == 18432000L // hand-tuned correction: 888
+    #elif F_CPU == 18432000L || F_CPU == 9216000L // 888, 444, etc.
         ((unsigned int) t << 8) - ((unsigned int) t << 5) - ((unsigned int) t << 1)
     #elif F_CPU == 18000000L // hand-tuned correction: 910
         (r = ((unsigned int) t << 8) - ((unsigned int) t << 5), r + (r >> 6))
     #elif F_CPU == 16500000L // hand-tuned correction: 992
         ((unsigned int) t << 8) - ((unsigned int) t << 3)
-    #elif F_CPU == 14745600L // hand-tuned correction: 1104, 552
+    #elif F_CPU == 14745600L || F_CPU == 7372800L // 1104, 552
         ((unsigned int) t << 7) + ((unsigned int) t << 3) + ((unsigned int) t << 1)
     #elif F_CPU == 11059200L // hand-tuned correction: 1472, 736
         ((unsigned int) t << 8) - ((unsigned int) t << 6) - ((unsigned int) t << 3)

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -117,11 +117,19 @@
 #define MICROSECONDS_PER_MILLIS_OVERFLOW (clockCyclesToMicroseconds(MillisTimer_Prescale_Value * 256))
 #endif
 #else
-// The key is never to compute (F_CPU / 1000000L), which may lose precision.
-// The formula below is correct for all F_CPU times that evenly divide by 100,
-// with prescaler values up to and including 512.
+/* The key is never to compute (F_CPU / 1000000L), which may lose precision.
+   The formula below is correct for all F_CPU times that evenly divide by 10,
+   at least for prescaler values up and including 64 as used in this file. */
+#if MillisTimer_Prescale_Value <= 64
 #define MICROSECONDS_PER_MILLIS_OVERFLOW \
-  (MillisTimer_Prescale_Value * 256L * 10000L / (F_CPU / 100L))
+  (MillisTimer_Prescale_Value * 256L * 1000L * 100L / (F_CPU / 10L))
+#else
+/* It may be sufficient to swap the 100L and 10L in the above formula,
+   but please double-check the EXACT_NUMERATOR macro below as well
+   and make sure it does not roll over. */
+#define MICROSECONDS_PER_MILLIS_OVERFLOW 0
+#error "Please adjust MICROSECONDS_PER_MILLIS_OVERFLOW formula"
+#endif
 #endif
 
 /* Correct millis to zero long term drift

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -122,7 +122,7 @@
    at least for prescaler values up and including 64 as used in this file. */
 #if MillisTimer_Prescale_Value <= 64
 #define MICROSECONDS_PER_MILLIS_OVERFLOW \
-  (MillisTimer_Prescale_Value * 256L * 1000L * 100L / (F_CPU / 10L))
+  (MillisTimer_Prescale_Value * 256UL * 1000UL * 100UL / (F_CPU / 10UL))
 #else
 /* It may be sufficient to swap the 100L and 10L in the above formula,
    but please double-check the EXACT_NUMERATOR macro below as well
@@ -152,8 +152,8 @@
    and divide the numerator by 8.  The calculation fits into a long int
    and produces the same right shift by 3 as the original code.
  */
-#define EXACT_NUMERATOR (MillisTimer_Prescale_Value * 256L * 12500L)
-#define EXACT_DENOMINATOR (F_CPU / 10L)
+#define EXACT_NUMERATOR (MillisTimer_Prescale_Value * 256UL * 12500UL)
+#define EXACT_DENOMINATOR (F_CPU / 10UL)
 
 /* The remainder is an integer in the range [0, EXACT_DENOMINATOR). */
 #define EXACT_REMAINDER \
@@ -181,10 +181,10 @@
 #if EXACT_REMAINDER > 0
 #define CORRECT_EXACT_MILLIS // enable zero drift correction in millis()
 #define CORRECT_EXACT_MICROS // enable zero drift correction in micros()
-#define CORRECT_EXACT_ROLL (135)
+#define CORRECT_EXACT_ROLL 135
 #define CORRECT_EXACT_ROLL_MINUS1 (CORRECT_EXACT_ROLL - 1)
 #define CORRECT_EXACT_MANY \
-  ((2L * 135L + 1L) * EXACT_REMAINDER / (2L * EXACT_DENOMINATOR))
+  ((2U * 135U + 1U) * EXACT_REMAINDER / (2U * EXACT_DENOMINATOR))
 #if CORRECT_EXACT_MANY < 0 || CORRECT_EXACT_MANY > 135
 #error "Miscalculation in millis() exactness correction"
 #endif
@@ -279,14 +279,14 @@
 #endif // CORRECT_EXACT_MICROS
 
 // the whole number of milliseconds per millis timer overflow
-#define MILLIS_INC (MICROSECONDS_PER_MILLIS_OVERFLOW / 1000)
+#define MILLIS_INC (MICROSECONDS_PER_MILLIS_OVERFLOW / 1000U)
 
 // the fractional number of milliseconds per millis timer overflow. we shift right
 // by three to fit these numbers into a byte. (for the clock speeds we care
 // about - 8 and 16 MHz - this doesn't lose precision.)
-#define FRACT_INC (((MICROSECONDS_PER_MILLIS_OVERFLOW % 1000) >> 3) \
+#define FRACT_INC (((MICROSECONDS_PER_MILLIS_OVERFLOW % 1000U) >> 3) \
                    CORRECT_FRACT_PLUSONE)
-#define FRACT_MAX (1000 >> 3)
+#define FRACT_MAX (1000U >> 3)
 
 #if INITIALIZE_SECONDARY_TIMERS
 static void initToneTimerInternal(void);

--- a/avr/cores/tiny/wiring.c
+++ b/avr/cores/tiny/wiring.c
@@ -422,12 +422,16 @@ static void initToneTimerInternal(void);
         ((unsigned int) t << 8) - ((unsigned int) t << 3)
     #elif F_CPU == 14745600L || F_CPU == 7372800L // 1104, 552
         ((unsigned int) t << 7) + ((unsigned int) t << 3) + ((unsigned int) t << 1)
+    #elif F_CPU == 12000000L || F_CPU == 6000000L // 1360, 680
+        (r = ((unsigned int) t << 7) + ((unsigned int) t << 5), r + (r >> 4))
     #elif F_CPU == 11059200L // hand-tuned correction: 1472, 736
         ((unsigned int) t << 8) - ((unsigned int) t << 6) - ((unsigned int) t << 3)
     #else // general catch-all
     #if !defined CORRECT_BITS || !defined CORRECT_BIT7
     #error "micros() correction relies on bit 7 to be defined"
     #endif
+        /* This code takes a lot of cycles due to one loop for each shift.
+           If you ever get here, optimize by ((((t << 1) + t) << 1) + t)... */
         ((unsigned int) t << 7)
     #ifdef CORRECT_BIT6
       + ((unsigned int) t << 6)


### PR DESCRIPTION
HI, I've separated the micros and millis pull requests. This one is for micros. It relies on #483.

I got rid of the multiply formula by some preprocessor math used for bit shifts and adds.
The multiply function call is gone from the assembly. Code size went up slightly.

Curious about how it all works for you.