### PR TITLE
Add CI workflow to check for broken links in docs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,30 @@
+name: Check Links
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-links.yml"
+      - "**.md"
+  pull_request:
+    paths:
+      - ".github/workflows/check-links.yml"
+      - "**.md"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to the linked sites.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: yes


### PR DESCRIPTION
On every push, pull request, and periodically, run [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links in the Markdown files of the repository.

Reference: https://github.com/SpenceKonde/ATTinyCore/issues/500#issuecomment-769576611

Demonstration workflow run: https://github.com/per1234/ATTinyCore/actions/runs/520812336