### PR TITLE
Fixing incorrect pin to interrupt macros

### DIFF
--- a/avr/variants/tinyX61_New/pins_arduino.h
+++ b/avr/variants/tinyX61_New/pins_arduino.h
@@ -157,9 +157,9 @@ static const uint8_t A10 = 0x80 | 10;
 
 
 #define digitalPinToPCICR(p)    (((p) >= 0 && (p) <= 15) ? (&GIMSK) : ((uint8_t *)NULL))
-#define digitalPinToPCICRbit(p) (((p) >= 8 )? 5 : 4)
-#define digitalPinToPCMSK(p)    (((p) >= 0 && (p) <= 16) ? ((p<8)?(&PCMSK0) : (&PCMSK0)) : ((uint8_t *)NULL))
-#define digitalPinToPCMSKbit(p) (1<<((p)&0x07))
+#define digitalPinToPCICRbit(p) (((p) >= 8 && (p) <= 11) ? (PCIE0) : (PCIE1))
+#define digitalPinToPCMSK(p)    (((p) >= 0 && (p) <= 16) ? ((p<8)?(&PCMSK0) : (&PCMSK1)) : ((uint8_t *)NULL))
+#define digitalPinToPCMSKbit(p) ((p) & 0x07)
 
 
 #define digitalPinToInterrupt(p)  ((p) == 14 ? 0 : ((p)==2?1: NOT_AN_INTERRUPT))


### PR DESCRIPTION
Working on changes discussed in #589 with @NicoHood.

Changed digitalPinToPCMSKbit to return the bit index instead of a mask on PCMSK (removed shift).
Fix a potential typo in digitalPinToPCMSK so that it will return PCMSK1 for port B pins.
Fixed digitalPinToPCICRbit so that PCIE0 is only returned for pins PB0 to PB3. Use PCIE1 for all other pins.