### PR TITLE
Add support for timeouts to improve hard realtime operation

### DIFF
--- a/avr/libraries/Wire/src/USI_TWI_Master/USI_TWI_Master.h
+++ b/avr/libraries/Wire/src/USI_TWI_Master/USI_TWI_Master.h
@@ -23,6 +23,8 @@
 *                     returns with a fail, then use USI_TWI_Get_Status_Info to evaluate the
 *                     cause of the failure.
 *
+* Modified 2021 by Anthony Zhang (me@anthonyz.ca) to implement timeouts
+
 ****************************************************************************/
 
 #include <avr/io.h>
@@ -64,6 +66,7 @@
 #define USI_TWI_NO_ACK_ON_ADDRESS 0x06 // The slave did not acknowledge  the address
 #define USI_TWI_MISSING_START_CON 0x07 // Generated Start Condition not detected on bus
 #define USI_TWI_MISSING_STOP_CON 0x08  // Generated Stop Condition not detected on bus
+#define USI_TWI_TIMEOUT 0x09           // Timeout occurred during bus operation, hard reset recommended
 
 
 #include "pins_arduino.h"
@@ -79,8 +82,11 @@
 //********** Prototypes **********//
 
 void USI_TWI_Master_Initialise(void);
+void USI_TWI_Master_Disable(void);
 void USI_TWI_Master_Speed(uint8_t);
 unsigned char USI_TWI_Start_Transceiver_With_Data_Stop(unsigned char *, unsigned char, unsigned char);
 unsigned char USI_TWI_Start_Transceiver_With_Data(unsigned char *, unsigned char);
 unsigned char USI_TWI_Get_State_Info(void);
+void USI_TWI_Master_Timeout(uint32_t, unsigned char);
+unsigned char USI_TWI_Master_Manage_Timeout_Flag(unsigned char);
 #endif

--- a/avr/libraries/Wire/src/Wire.h
+++ b/avr/libraries/Wire/src/Wire.h
@@ -76,6 +76,9 @@ class TwoWire : public Stream
     void begin(int);
     void end();
     void setClock(uint32_t);
+    void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
+    bool getWireTimeoutFlag(void);
+    void clearWireTimeoutFlag(void);
     void beginTransmission(uint8_t);
     void beginTransmission(int);
     uint8_t endTransmission(void);
@@ -131,6 +134,9 @@ class TwoWire {
     void begin(int);
     void end();
     void setClock(uint32_t);
+    void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
+    bool getWireTimeoutFlag(void);
+    void clearWireTimeoutFlag(void);
     void beginTransmission(uint8_t);
     void beginTransmission(int);
     uint8_t endTransmission(void);
@@ -178,6 +184,9 @@ public:
   void begin(int);
   void end();
   void setClock(uint32_t);
+  void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
+  bool getWireTimeoutFlag(void);
+  void clearWireTimeoutFlag(void);
   void beginTransmission(uint8_t);
   void beginTransmission(int);
   uint8_t endTransmission(void);

--- a/avr/libraries/Wire/src/twi.c
+++ b/avr/libraries/Wire/src/twi.c
@@ -17,16 +17,17 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
 */
-
 
 #include <math.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <avr/io.h>
 #include <avr/interrupt.h>
+#include <util/delay.h>
 #include <compat/twi.h>
-#include "Arduino.h" // for digitalWrite
+#include "Arduino.h" // for digitalWrite and micros
 
 #ifdef TWDR
 #ifndef cbi
@@ -44,6 +45,16 @@ static volatile uint8_t twi_state;
 static volatile uint8_t twi_slarw;
 static volatile uint8_t twi_sendStop;     // should the transaction end with a stop
 static volatile uint8_t twi_inRepStart;     // in the middle of a repeated start
+
+// twi_timeout_us > 0 prevents the code from getting stuck in various while loops here
+// if twi_timeout_us == 0 then timeout checking is disabled (the previous Wire lib behavior)
+// at some point in the future, the default twi_timeout_us value could become 25000
+// and twi_do_reset_on_timeout could become true
+// to conform to the SMBus standard
+// http://smbus.org/specs/SMBus_3_1_20180319.pdf
+static volatile uint32_t twi_timeout_us = 0ul;
+static volatile bool twi_timed_out_flag = false;  // a timeout has been seen
+static volatile bool twi_do_reset_on_timeout = false;  // reset the TWI registers on timeout
 
 static void (*twi_onSlaveTransmit)(void);
 static void (*twi_onSlaveReceive)(uint8_t*, int);
@@ -120,6 +131,12 @@ void twi_setAddress(uint8_t address)
   TWAR = address << 1;
 }
 
+/*
+ * Function twi_setClock
+ * Desc     sets twi bit rate
+ * Input    Clock Frequency
+ * Output   none
+ */
 void twi_setFrequency(uint32_t frequency)
 {
   TWBR = ((F_CPU / frequency) - 16) / 2;
@@ -150,8 +167,12 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
   }
 
   // wait until twi is ready, become master receiver
+  uint32_t startMicros = micros();
   while(TWI_READY != twi_state){
-    continue;
+    if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+      twi_handleTimeout(twi_do_reset_on_timeout);
+      return 0;
+    }
   }
   twi_state = TWI_MRX;
   twi_sendStop = sendStop;
@@ -179,18 +200,27 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     // up. Also, don't enable the START interrupt. There may be one pending from the
     // repeated start that we sent ourselves, and that would really confuse things.
     twi_inRepStart = false;     // remember, we're dealing with an ASYNC ISR
+    startMicros = micros();
     do {
       TWDR = twi_slarw;
+      if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+        twi_handleTimeout(twi_do_reset_on_timeout);
+        return 0;
+      }
     } while(TWCR & _BV(TWWC));
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);  // enable INTs, but not START
-  }
-  else
+  } else {
     // send start condition
     TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT) | _BV(TWSTA);
+  }
 
   // wait for read operation to complete
+  startMicros = micros();
   while(TWI_MRX == twi_state){
-    continue;
+    if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+      twi_handleTimeout(twi_do_reset_on_timeout);
+      return 0;
+    }
   }
 
   if (twi_masterBufferIndex < length)
@@ -218,6 +248,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
  *          2 .. address send, NACK received
  *          3 .. data send, NACK received
  *          4 .. other twi error (lost bus arbitration, bus error, ..)
+ *          5 .. timeout
  */
 uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop)
 {
@@ -229,8 +260,12 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
   }
 
   // wait until twi is ready, become master transmitter
+  uint32_t startMicros = micros();
   while(TWI_READY != twi_state){
-    continue;
+    if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+      twi_handleTimeout(twi_do_reset_on_timeout);
+      return (5);
+    }
   }
   twi_state = TWI_MTX;
   twi_sendStop = sendStop;
@@ -261,18 +296,27 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     // up. Also, don't enable the START interrupt. There may be one pending from the
     // repeated start that we sent ourselves, and that would really confuse things.
     twi_inRepStart = false;     // remember, we're dealing with an ASYNC ISR
+    startMicros = micros();
     do {
       TWDR = twi_slarw;
+      if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+        twi_handleTimeout(twi_do_reset_on_timeout);
+        return (5);
+      }
     } while(TWCR & _BV(TWWC));
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);  // enable INTs, but not START
-  }
-  else
+  } else {
     // send start condition
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA); // enable INTs
+  }
 
   // wait for write operation to complete
+  startMicros = micros();
   while(wait && (TWI_MTX == twi_state)){
-    continue;
+    if((twi_timeout_us > 0ul) && ((micros() - startMicros) > twi_timeout_us)) {
+      twi_handleTimeout(twi_do_reset_on_timeout);
+      return (5);
+    }
   }
 
   if (twi_error == 0xFF)
@@ -369,8 +413,19 @@ void twi_stop(void)
 
   // wait for stop condition to be executed on bus
   // TWINT is not set after a stop condition!
+  // We cannot use micros() from an ISR, so approximate the timeout with cycle-counted delays
+  const uint8_t us_per_loop = 8;
+  uint32_t counter = (twi_timeout_us + us_per_loop - 1)/us_per_loop; // Round up
   while(TWCR & _BV(TWSTO)){
-    continue;
+    if(twi_timeout_us > 0ul){
+      if (counter > 0ul){
+        _delay_us(us_per_loop);
+        counter--;
+      } else {
+        twi_handleTimeout(twi_do_reset_on_timeout);
+        return;
+      }
+    }
   }
 
   // update twi state
@@ -390,6 +445,59 @@ void twi_releaseBus(void)
 
   // update twi state
   twi_state = TWI_READY;
+}
+
+/*
+ * Function twi_setTimeoutInMicros
+ * Desc     set a timeout for while loops that twi might get stuck in
+ * Input    timeout value in microseconds (0 means never time out)
+ * Input    reset_with_timeout: true causes timeout events to reset twi
+ * Output   none
+ */
+void twi_setTimeoutInMicros(uint32_t timeout, bool reset_with_timeout){
+  twi_timed_out_flag = false;
+  twi_timeout_us = timeout;
+  twi_do_reset_on_timeout = reset_with_timeout;
+}
+
+/*
+ * Function twi_handleTimeout
+ * Desc     this gets called whenever a while loop here has lasted longer than
+ *          twi_timeout_us microseconds. always sets twi_timed_out_flag
+ * Input    reset: true causes this function to reset the twi hardware interface
+ * Output   none
+ */
+void twi_handleTimeout(bool reset){
+  twi_timed_out_flag = true;
+
+  if (reset) {
+    // remember bitrate and address settings
+    uint8_t previous_TWBR = TWBR;
+    uint8_t previous_TWAR = TWAR;
+
+    // reset the interface
+    twi_disable();
+    twi_init();
+
+    // reapply the previous register values
+    TWAR = previous_TWAR;
+    TWBR = previous_TWBR;
+  }
+}
+
+/*
+ * Function twi_manageTimeoutFlag
+ * Desc     returns true if twi has seen a timeout
+ *          optionally clears the timeout flag
+ * Input    clear_flag: true if we should reset the hardware
+ * Output   the value of twi_timed_out_flag when the function was called
+ */
+bool twi_manageTimeoutFlag(bool clear_flag){
+  bool flag = twi_timed_out_flag;
+  if (clear_flag){
+    twi_timed_out_flag = false;
+  }
+  return(flag);
 }
 
 ISR(TWI_vect)
@@ -441,6 +549,7 @@ ISR(TWI_vect)
     case TW_MR_DATA_ACK: // data received, ack sent
       // put byte into buffer
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
+      __attribute__ ((fallthrough));
     case TW_MR_SLA_ACK:  // address sent, ack received
       // ack if more bytes are expected, otherwise nack
       if(twi_masterBufferIndex < twi_masterBufferLength){
@@ -526,6 +635,7 @@ ISR(TWI_vect)
         twi_txBufferLength = 1;
         twi_txBuffer[0] = 0x00;
       }
+      __attribute__ ((fallthrough));
       // transmit first byte from buffer, fall
     case TW_ST_DATA_ACK: // byte sent, ack returned
       // copy data to output register

--- a/avr/libraries/Wire/src/twi.h
+++ b/avr/libraries/Wire/src/twi.h
@@ -15,6 +15,8 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
 */
 #ifdef TWDR
 #ifndef twi_h
@@ -50,6 +52,9 @@
   void twi_reply(uint8_t);
   void twi_stop(void);
   void twi_releaseBus(void);
+  void twi_setTimeoutInMicros(uint32_t, bool);
+  void twi_handleTimeout(bool);
+  bool twi_manageTimeoutFlag(bool);
 
 #endif
 #endif


### PR DESCRIPTION
Most I2C master examples will [hang the processor forever if an I2C slave device becomes unresponsive](https://spellfoundry.com/2020/06/25/reliable-embedded-systems-recovering-arduino-i2c-bus-lock-ups/). As a result, the ArduinoCore-avr libraries [recently added a number of new methods](https://github.com/arduino/ArduinoCore-avr/issues/42) to the Wire library, to allow programs to recover from these conditions (e.g., by hard resetting the device).

This PR adds support for timeouts in the hardware-TWI and USI versions of ATTinyCore's Wire library.

* Add timeout support in the TWI version of the Wire library.
    * The original work comes from Greyson Christoforo (grey@christoforo.net) - this PR just copies their changes over from [ArduinoCore-avr's Wire library](https://github.com/arduino/ArduinoCore-avr/blob/1ac42f7ac0c365cfa4d901889ff6d4c23d3b4796/libraries/Wire/src/Wire.cpp) and makes some minor style fixes.
* Add timeout support in the USI-TWI version of the Wire library.
    * I used Greyson's work as a reference, so it looks quite similar. Essentially, anywhere that can block indefinitely, we implement a timeout to ensure an upper bound on time spent.

Testing
---

I only tested this on an ATTiny84A, so only the USI part of it got tested, the hardware-TWI part could really use some more. I used the test sketch from https://github.com/arduino/reference-en/issues/895:

```
#include <Wire.h>

void setup() {
  Wire.begin(); // join i2c bus (address optional for master)
  #if defined(WIRE_HAS_TIMEOUT)
    Wire.setWireTimeout(3000 /* us */, true /* reset_on_timeout */);
  #endif
}

byte x = 0;

void loop() {
  /* First, send a command to the other device */
  Wire.beginTransmission(8); // transmit to device arduino/Arduino#8
  Wire.write(123);           // send command
  byte error = Wire.endTransmission(); // run transaction
  if (error) {
    Serial.println("Error occured when writing");
    if (error == 5)
      Serial.println("It was a timeout");
  }

  delay(100);

  /* Then, read the result */
  #if defined(WIRE_HAS_TIMEOUT)
  Wire.clearWireTimeoutFlag();
  #endif
  byte len = Wire.requestFrom(8, 1); // request 1 byte from device arduino/Arduino#8
  if (len == 0) {
    Serial.println("Error occured when reading");
    #if defined(WIRE_HAS_TIMEOUT)
    if (Wire.getWireTimeoutFlag())
      Serial.println("It was a timeout");
    #endif
  }



  delay(100);
}
```

To trigger a hang, I tied SCL low, preventing any device from raising the clock line - this represents a situation where the I2C device might be misbehaving. When I did, the timeout triggered, as expected, and the USI interface reset.