### PR TITLE
update Print.h on v2.0.0-dev for consistency with other Arduino Cores

### DIFF
--- a/avr/cores/tiny/Print.h
+++ b/avr/cores/tiny/Print.h
@@ -78,7 +78,10 @@ class Print
     void clearWriteError() { setWriteError(0); }
 
     virtual size_t write(uint8_t) = 0;
-    size_t write(const char *str) { return write((const uint8_t *)str, strlen(str)); }
+    size_t write(const char *str) {
+      if (str == NULL) return 0;
+      return write((const uint8_t *)str, strlen(str));
+    }
     virtual size_t write(const uint8_t *buffer, size_t size);
     size_t write(const char *buffer, size_t size) {
       return write((const uint8_t *)buffer, size);

--- a/avr/cores/tiny/Print.h
+++ b/avr/cores/tiny/Print.h
@@ -80,6 +80,9 @@ class Print
     virtual size_t write(uint8_t) = 0;
     size_t write(const char *str) { return write((const uint8_t *)str, strlen(str)); }
     virtual size_t write(const uint8_t *buffer, size_t size);
+    size_t write(const char *buffer, size_t size) {
+      return write((const uint8_t *)buffer, size);
+    }
 
     size_t print(fstr_t*);
     size_t print(const String &);


### PR DESCRIPTION
I ran into an API inconsistency (compared to other Arduino Cores) with the `Print.h` class in ATTinyCore 1.5.2, which produces a compiler error with one of my libraries on the ATtiny85. While fixing that, I noticed another incosistency in `Print.h`, so I'm sending you a commit for that as well.

Two commits follow:

* adds an overload for `write(const char *buffer, size_t size)` that exists on all other Arduino core, except for ATTinyCore
* check for `NULL` before calling `strlen()`, to make ATTinyCore consistent with other Arduino Cores

I can send this exact same PR on the `master` branch if requested. 