### PR TITLE
Fix optiboot hex file paths

### DIFF
--- a/avr/extras/development/boards.txt
+++ b/avr/extras/development/boards.txt
@@ -823,7 +823,7 @@ attinyx8.menu.clock.extclk_3686k.build.clocksource=2
 ################################
 attinyx8.menu.pinmap.default=Standard
 attinyx8.menu.pinmap.mhet=MH-ET Tiny
-attinyx8.menu.pinmap.mhet.build.variant=tinyx8_MH
+attinyx8.menu.pinmap.mhet.build.variant=tinyx8_mh
 attinyx8.menu.pinmap.default.build.pinmapabr=
 attinyx8.menu.pinmap.mhet.build.pinmapabr=.mhet
 
@@ -2497,7 +2497,7 @@ attinyx313.menu.clock.internal_2m.build.clocksource=0x10
 attinyx313.menu.clock.internal_2m.bootloader.f_cpu=1000000UL
 attinyx313.menu.clock.internal_500k=0.5 MHz (internal)
 attinyx313.menu.clock.internal_500k.bootloader.low_fuses=0x62
-attinyx313.menu.clock.internal_500k.build.f_cpu=2000000UL
+attinyx313.menu.clock.internal_500k.build.f_cpu=500000UL
 attinyx313.menu.clock.internal_500k.build.speed=500k
 attinyx313.menu.clock.internal_500k.build.clocksource=0x10
 attinyx313.menu.clock.internal_500k.bootloader.f_cpu=500000UL
@@ -3086,9 +3086,9 @@ attinyx4opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx4opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx4opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx4opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx4opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx4opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx4opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -3377,9 +3377,9 @@ attinyx5opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx5opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx5opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx5opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx5opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx5opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx5opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -3559,7 +3559,7 @@ attinyx8opti.menu.clock.extclk_3686k.upload.speed=14400
 ################################
 attinyx8opti.menu.pinmap.default=Standard
 attinyx8opti.menu.pinmap.mhet=MH-ET Tiny
-attinyx8opti.menu.pinmap.,mhet.build.variant=tinyx8_MH
+attinyx8opti.menu.pinmap.,mhet.build.variant=tinyx8_mh
 attinyx8opti.menu.pinmap.default.build.pinmapabr=
 attinyx8opti.menu.pinmap.mhet.build.pinmapabr=.mhet
 
@@ -3597,9 +3597,9 @@ attinyx8opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx8opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx8opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx8opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx8opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx8opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx8opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -3877,9 +3877,9 @@ attinyx7opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx7opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx7opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx7opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx7opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx7opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx7opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -4191,9 +4191,9 @@ attinyx61opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx61opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx61opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx61opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx61opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx61opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx61opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -4519,9 +4519,9 @@ attinyx41opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attinyx41opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attinyx41opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attinyx41opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attinyx41opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attinyx41opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attinyx41opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 ################################
 # Serial Port:                 #
@@ -4758,9 +4758,9 @@ attiny828opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attiny828opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attiny828opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attiny828opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attiny828opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attiny828opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attiny828opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 
 #*******************************************************************************
@@ -5050,9 +5050,9 @@ attiny1634opti.menu.millis.disabled.build.millisabr=mNONE
 # Boot Entrymode menu          #
 ################################
 attiny1634opti.menu.bootentry.1s=Standard (1s wait, for use w/autoreset)
-attiny1634opti.menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
+attiny1634opti.menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex
 attiny1634opti.menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)
-attiny1634opti.menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
+attiny1634opti.menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex
 
 ################################
 # Serial Port:                 #
@@ -5138,6 +5138,12 @@ attiny84mi12.menu.clock.internal_12m.build.f_cpu=12000000UL
 attiny84mi12.menu.clock.internal_12m.build.speed=12m
 attiny84mi12.menu.clock.internal_12m.build.clocksource=0
 attiny84mi12.menu.clock.internal_12m.build.extra_flags=-DBOOT_TUNED120
+attiny84mi12.menu.clock.internal_1m=1 MHz internal
+attiny84mi12.menu.clock.internal_1m.bootloader.low_fuses=0x62
+attiny84mi12.menu.clock.internal_1m.build.f_cpu=1000000UL
+attiny84mi12.menu.clock.internal_1m.build.speed=1m
+attiny84mi12.menu.clock.internal_1m.build.clocksource=0
+attiny84mi12.menu.clock.internal_1m.build.extra_flags=-DBOOT_TUNED120
 
 ################################
 # Pin Mapping menu             #
@@ -5287,6 +5293,12 @@ attiny84micr.menu.clock.internal_12m8.build.f_cpu=12800000L
 attiny84micr.menu.clock.internal_12m8.build.speed=12m8
 attiny84micr.menu.clock.internal_12m8.build.clocksource=0
 attiny84micr.menu.clock.internal_12m8.build.extra_flags=-DBOOT_TUNED128
+attiny84micr.menu.clock.internal_1m=1 MHz internal
+attiny84micr.menu.clock.internal_1m.bootloader.low_fuses=0x62
+attiny84micr.menu.clock.internal_1m.build.f_cpu=1000000UL
+attiny84micr.menu.clock.internal_1m.build.speed=1m
+attiny84micr.menu.clock.internal_1m.build.clocksource=0
+attiny84micr.menu.clock.internal_1m.build.extra_flags=-DBOOT_TUNED128
 
 ################################
 # Pin Mapping menu             #
@@ -5425,11 +5437,11 @@ attiny85micr.upload.maximum_data_size=512
 # Clocking menu options        #
 ################################
 attiny85micr.build.extra_flags=-DBOOT_TUNED165
-attiny85micr.menu.clock.pll_165m=16.5 MHz (internal tuned PLL)
-attiny85micr.menu.clock.pll_165m.bootloader.low_fuses=0xF1
-attiny85micr.menu.clock.pll_165m.build.f_cpu=16500000UL
-attiny85micr.menu.clock.pll_165m.build.speed=16m5
-attiny85micr.menu.clock.pll_165m.build.clocksource=6
+attiny85micr.menu.clock.pll_16m5=16.5 MHz (internal tuned PLL)
+attiny85micr.menu.clock.pll_16m5.bootloader.low_fuses=0xF1
+attiny85micr.menu.clock.pll_16m5.build.f_cpu=16500000UL
+attiny85micr.menu.clock.pll_16m5.build.speed=16m5
+attiny85micr.menu.clock.pll_16m5.build.clocksource=6
 attiny85micr.menu.clock.pll_16m=16 MHz (internal PLL)
 attiny85micr.menu.clock.pll_16m.bootloader.low_fuses=0xF1
 attiny85micr.menu.clock.pll_16m.build.f_cpu=16000000UL
@@ -5542,7 +5554,7 @@ attiny85micr.menu.burnmode.install.bootloader.flashstring=-Uflash:w:{bootloader.
 
 attiny88micr.build.board=AVR_ATTINY88
 attiny88micr.build.core=tiny
-attiny88micr.build.variant=tinyx8_MH
+attiny88micr.build.variant=tinyx8_mh
 attiny88micr.build.export_merged_output=false
 attiny88micr.bootloader.extended_fuses=0xFE
 attiny88micr.bootloader.high_fuses=0b{bootloader.rstbit}1011{bootloader.bod_bits}
@@ -5608,7 +5620,7 @@ attiny88micr.menu.clock.extclk_1m.build.clocksource=0x12
 ################################
 attiny88micr.menu.pinmap.mhet=MH-Tiny
 attiny88micr.menu.pinmap.default=Standard
-attiny88micr.menu.pinmap.mhet.build.variant=tinyx8_MH
+attiny88micr.menu.pinmap.mhet.build.variant=tinyx8_mh
 attiny88micr.menu.pinmap.default.build.pinmapabr=
 attiny88micr.menu.pinmap.mhet.build.pinmapabr=.mhet
 
@@ -6043,11 +6055,11 @@ attiny861micr.upload.maximum_data_size=512
 # Clocking menu options        #
 ################################
 attiny861micr.build.extra_flags=-DBOOT_TUNED165
-attiny861micr.menu.clock.pll_165m=16.5 MHz (internal tuned PLL)
-attiny861micr.menu.clock.pll_165m.bootloader.low_fuses=0xF1
-attiny861micr.menu.clock.pll_165m.build.f_cpu=16500000UL
-attiny861micr.menu.clock.pll_165m.build.speed=16m5
-attiny861micr.menu.clock.pll_165m.build.clocksource=6
+attiny861micr.menu.clock.pll_16m5=16.5 MHz (internal tuned PLL)
+attiny861micr.menu.clock.pll_16m5.bootloader.low_fuses=0xF1
+attiny861micr.menu.clock.pll_16m5.build.f_cpu=16500000UL
+attiny861micr.menu.clock.pll_16m5.build.speed=16m5
+attiny861micr.menu.clock.pll_16m5.build.clocksource=6
 attiny861micr.menu.clock.pll_16m=16 MHz (internal PLL)
 attiny861micr.menu.clock.pll_16m.bootloader.low_fuses=0xF1
 attiny861micr.menu.clock.pll_16m.build.f_cpu=16000000UL
@@ -6089,6 +6101,24 @@ attiny861micr.menu.remap.default.build.remap=
 attiny861micr.menu.remap.alternate.build.remap=-DSET_REMAPUSI
 attiny861micr.menu.remap.default.build.remapabr=
 attiny861micr.menu.remap.alternate.build.remapabr=rU
+
+################################
+# Software Serial menu         #
+################################
+attiny861micr.menu.softserial861.enable_AIN1=RX on PA7, TX on PA (default PA6)
+attiny861micr.menu.softserial861.enable_AIN0=RX on PA6, TX on PA (default PA7)
+attiny861micr.menu.softserial861.enable_AIN0.build.softser=-DSOFTSERIAL_RXAIN0
+attiny861micr.menu.softserial861.enable_AIN0.build.softserabr=ssAIN0
+attiny861micr.menu.softserial861.enable_AIN2=RX on PA5, TX on PA (default PA6)
+attiny861micr.menu.softserial861.enable_AIN2.build.softser=-DSOFTSERIAL_RXAIN2
+attiny861micr.menu.softserial861.enable_AIN2.build.softserabr=ssAIN2
+attiny861micr.menu.softserial861.txonly=No receiving, transmit only. TX on PA, default PA6.
+attiny861micr.menu.softserial861.txonly.build.softserabr=ssTX
+attiny861micr.menu.softserial861.txonly.build.softser=-DSOFT_TX_ONLY
+attiny861micr.menu.softserial861.enable_AIN1.bootloader.uart=_rx7tx6
+attiny861micr.menu.softserial861.enable_AIN0.bootloader.uart=_rx6tx7
+attiny861micr.menu.softserial861.enable_AIN2.bootloader.uart=_rx5tx6
+attiny861micr.menu.softserial861.txonly.bootloader.uart=_rx7tx6
 
 ################################
 # BrownOut Detect menu         #
@@ -6220,6 +6250,12 @@ attiny841micr.menu.clock.internal_12m.build.f_cpu=12000000UL
 attiny841micr.menu.clock.internal_12m.build.speed=12m
 attiny841micr.menu.clock.internal_12m.build.clocksource=0
 attiny841micr.menu.clock.internal_12m.build.extra_flags=-DBOOT_TUNED120
+attiny841micr.menu.clock.internal_1m=1 MHz internal
+attiny841micr.menu.clock.internal_1m.bootloader.low_fuses=0x62
+attiny841micr.menu.clock.internal_1m.build.f_cpu=1000000UL
+attiny841micr.menu.clock.internal_1m.build.speed=1m
+attiny841micr.menu.clock.internal_1m.build.clocksource=0
+attiny841micr.menu.clock.internal_1m.build.extra_flags=-DBOOT_TUNED120
 
 ################################
 # Pin Mapping menu             #
@@ -6396,6 +6432,12 @@ attiny1634micr.menu.clock.internal_12m.build.f_cpu=12000000UL
 attiny1634micr.menu.clock.internal_12m.build.speed=12m
 attiny1634micr.menu.clock.internal_12m.build.clocksource=0
 attiny1634micr.menu.clock.internal_12m.build.extra_flags=-DBOOT_TUNED120
+attiny1634micr.menu.clock.internal_1m=1 MHz internal
+attiny1634micr.menu.clock.internal_1m.bootloader.low_fuses=0x62
+attiny1634micr.menu.clock.internal_1m.build.f_cpu=1000000UL
+attiny1634micr.menu.clock.internal_1m.build.speed=1m
+attiny1634micr.menu.clock.internal_1m.build.clocksource=0
+attiny1634micr.menu.clock.internal_1m.build.extra_flags=-DBOOT_TUNED120
 
 ################################
 # Pin Mapping menu             #

--- a/avr/extras/development/create_boards_txt.py
+++ b/avr/extras/development/create_boards_txt.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 import re
 
 clocktobaud = {
@@ -309,8 +310,8 @@ resetpinmenu = [
   "gpio=I/O pin - DANGER: If anything goes wrong, only HV programming can unbrick!","gpio.bootloader.rstbit=0"]
 
 bootmodesopti = [
-  ".menu.bootentry.1s=Standard (1s wait, for use w/autoreset)",".menu.bootentry.1s.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex",
-  ".menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)",".menu.bootentry.8s_8sec.bootloader.file=optiboot/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex"]
+  ".menu.bootentry.1s=Standard (1s wait, for use w/autoreset)",".menu.bootentry.1s.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}.hex",
+  ".menu.bootentry.8s=8-second (8s wait, for use w. out/autoreset)",".menu.bootentry.8s_8sec.bootloader.file={runtime.platform.path}/bootloaders/optiboot/hex/optiboot_{build.mcu}_{build.f_cpu}{bootloader.uart}_8sec.hex"]
 
 bootmodesmicr = [
   ".menu.bootentry.extrf_porf=External Reset and Power On Reset",".menu.bootentry.extrf_porf.bootloader.entrymode=extrf_porf",


### PR DESCRIPTION
- Optiboot hex file paths are not lined up correctly. This provides a fix for avr/extras/development/create_boards_txt.py.
-  Tested with ATTiny841 chips, using a USBTinyISPs