### PR TITLE
Update redirecting URLs in bundled library metadata

### DIFF
--- a/avr/libraries/EEPROM/library.properties
+++ b/avr/libraries/EEPROM/library.properties
@@ -5,5 +5,5 @@ maintainer=None
 sentence=Enables reading and writing to the permanent board storage for all classic AVR devices.
 paragraph=This is a copy of the official library from Arduino. No maintenance will be performed beyond copying the official version if a new one becomes available.
 category=Data Storage
-url=http://www.arduino.cc/en/Reference/EEPROM
+url=https://docs.arduino.cc/learn/built-in-libraries/eeprom
 architectures=avr

--- a/avr/libraries/SPI/library.properties
+++ b/avr/libraries/SPI/library.properties
@@ -5,5 +5,5 @@ maintainer=Spence Konde <spencekonde@gmail.com>
 sentence=Supports SPI master communication on all ATTinyCore supported parts.
 paragraph=This is intended as a "drop-in" replacement for the normal Wire library. Unlike ATmega parts, most classic ATtiny devices do not have a proper hardware SPI interface - they have a USI. This library uses the USI (unless there is a real hardware SPI module, such as on the ATtiny841, or ATtiny88) and uses it for SPI, presenting a compatible API. Changing clock speed doesn't work; no other issues are known.
 category=Communication
-url=http://arduino.cc/en/Reference/SPI
+url=https://www.arduino.cc/reference/en/language/functions/communication/spi/
 architectures=avr

--- a/avr/libraries/Servo/library.properties
+++ b/avr/libraries/Servo/library.properties
@@ -5,5 +5,5 @@ maintainer=Spence Konde <spencekonde@gmail.com>
 sentence=Allows ATTinyCore-supported parts to control a variety of servo motors.
 paragraph=If the Servo library has been installed into <sketchbook>/libraries, it will be used instead. It probably doesn't support the ATTinyCore devices. In this case, use Servo_ATTinyCore.h instead of Servo.h. This library can control 12 servos using only 1 timer.
 category=Device Control
-url=http://www.arduino.cc/en/Reference/Servo
+url=https://www.arduino.cc/reference/en/libraries/servo/
 architectures=avr,sam,samd

--- a/avr/libraries/Servo_ATTinyCore/library.properties
+++ b/avr/libraries/Servo_ATTinyCore/library.properties
@@ -5,5 +5,5 @@ maintainer=Spence Konde <spencekonde@gmail.com>
 sentence=Allows ATTinyCore supported parts to control a variety of servo motors. This is a renamed copy so user can force the IDE to use the core-associated library.
 paragraph=If the Servo library has been installed into <sketchbook>/libraries, it will be used instead. It probably doesn't support the ATTinyCore devices. In this case, use Servo_ATTinyCore.h instead of Servo.h. This library can control 12 servos using only 1 timer.
 category=Device Control
-url=http://www.arduino.cc/en/Reference/Servo
+url=https://www.arduino.cc/reference/en/libraries/servo/
 architectures=avr,sam,samd

--- a/avr/libraries/SoftwareSerial/library.properties
+++ b/avr/libraries/SoftwareSerial/library.properties
@@ -5,6 +5,6 @@ maintainer=None
 sentence=This is an exact copy of the normal classic AVR SoftwareSerial library, with all it's downsides and flaws. ATTinyCore includes a better software serial implementation on fixed pins which does not take over every pin change interrupt like this one does.
 paragraph=No maintenance will be performed beyond copying the official version if a new one becomes available.
 category=Communication
-url=http://arduino.cc/en/Reference/SoftwareSerial
+url=https://docs.arduino.cc/learn/built-in-libraries/software-serial
 architectures=avr
 types=Arduino

--- a/avr/libraries/Wire/library.properties
+++ b/avr/libraries/Wire/library.properties
@@ -5,5 +5,5 @@ maintainer=Spence Konde <spencekonde@gmail.com>
 sentence=Supports I2C master or slave operation on all ATTinyCore-supported parts
 paragraph=YOU MUST ALWAYS USE HARDWARE PULLUP RESISTORS! Otherwise, this is intended as a "drop-in" replacement for the normal Wire library. Unlike ATmega parts, most classic ATtiny devices do not have a proper hardware TWI interface - they have a USI, or slave only interface. This library picks the appropriate hardware and presents a compatible API. Changing clock speed doesn't work. ATtiny841, 1634, 828, and 441 as master provide no way to determine if a timeout occurred.
 category=Communication
-url=http://www.arduino.cc/en/Reference/Wire
+url=https://www.arduino.cc/reference/en/language/functions/communication/wire/
 architectures=avr


### PR DESCRIPTION
The `url` field of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) points the user to where they might find more information or assistance for the library.

This platform includes [bundled libraries](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-bundled-libraries) which are variants of the standardized libraries distributed by Arduino. The `url` field in the metadata of these libraries points to the reference on the arduino.cc website, as that information is also applicable to this platform's variants of the libraries.

Due to restructuring of the arduino.cc website, the targeted reference pages have moved to a different URL. Arduino set up redirects from the previous URLs to the new one, but redirects have a tendency to break or no longer lead to the intended target over time so it is best to avoid relying on them. In addition, the use of redirecting URLs seems to make it more likely that automated link checks will fail (https://github.com/per1234/arduino-ci-script/issues/33) due to an HTTP 403 ("Forbidden") response code:

https://github.com/SpenceKonde/ATTinyCore/actions/runs/5339900593/jobs/9679095711

```text
ERROR: /home/runner/work/ATTinyCore/ATTinyCore/avr/libraries/Wire/library.properties: url value http://www.arduino.cc/en/Reference/Wire returned error status 403.
```

even though the URL does work as expected when a human loads it in their browser:

http://www.arduino.cc/en/Reference/Wire